### PR TITLE
Erweiterung, um Oberfläche als JAR zu erzeugen (zum Import in das API-Gateway)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bower_components/
 build/
 node_modules/
+target/
+nbproject/

--- a/polymer.json
+++ b/polymer.json
@@ -4,7 +4,7 @@
   "fragments": [
     "src/animad-keepers-view.html",
     "src/animad-animals-view.html",
-    "src/animad-view3.html",
+    "src/animad-enclosures-view.html",
     "src/animad-view404.html"
   ],
   "sources": [

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>de.muenchen.referenzarchitektur</groupId>
+    <artifactId>lhm_polymer</artifactId>
+    <name>lhm_polymer</name>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <organization>
+        <name>Landeshauptstadt München</name>
+        <url>http://www.muenchen.de/</url>
+    </organization>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>1.3.5.RELEASE</version>
+    </parent>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>exec-bower-install</id>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <executable>bower</executable>
+                            <arguments>
+                                <argument>install</argument>
+                            </arguments>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>exec-polymer-build</id>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <executable>polymer</executable>
+                            <arguments>
+                                <argument>build</argument>
+                            </arguments>
+                        </configuration>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                    </execution>                    
+                </executions>
+            </plugin>            
+        </plugins>
+
+        <resources>
+            <resource>
+                <directory>build/es6-bundled</directory>
+                <targetPath>static</targetPath>
+            </resource>
+        </resources>
+
+    </build>
+</project>


### PR DESCRIPTION
Dazu musste ich auch einen kleinen Bug in polymer.json fixen, der "polymer build" verhindert.

Zum Ausführen des pom.xml muss man auf der Kommandozeile "bower" und "polymer" aufrufen können.