### PR TITLE
 #193 Filtern für selektierbare Filter in <entity>-view

### DIFF
--- a/analysis.json
+++ b/analysis.json
@@ -13,11 +13,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 28,
+              "line": 27,
               "column": 20
             },
             "end": {
-              "line": 32,
+              "line": 31,
               "column": 21
             }
           },
@@ -35,11 +35,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 35,
+              "line": 34,
               "column": 20
             },
             "end": {
-              "line": 39,
+              "line": 38,
               "column": 21
             }
           },
@@ -58,11 +58,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 47,
+              "line": 46,
               "column": 12
             },
             "end": {
-              "line": 50,
+              "line": 49,
               "column": 13
             }
           },
@@ -75,11 +75,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 54,
+              "line": 53,
               "column": 12
             },
             "end": {
-              "line": 61,
+              "line": 60,
               "column": 13
             }
           },
@@ -96,11 +96,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 62,
               "column": 12
             },
             "end": {
-              "line": 65,
+              "line": 64,
               "column": 13
             }
           },
@@ -113,11 +113,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 67,
               "column": 12
             },
             "end": {
-              "line": 72,
+              "line": 71,
               "column": 13
             }
           },
@@ -130,11 +130,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 19,
+          "line": 18,
           "column": 8
         },
         "end": {
-          "line": 74,
+          "line": 73,
           "column": 9
         }
       },
@@ -147,11 +147,11 @@
           "description": "observer registrieren?",
           "sourceRange": {
             "start": {
-              "line": 35,
+              "line": 34,
               "column": 20
             },
             "end": {
-              "line": 39,
+              "line": 38,
               "column": 21
             }
           },
@@ -186,18 +186,41 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 149,
+              "line": 164,
               "column": 20
             },
             "end": {
-              "line": 154,
+              "line": 168,
               "column": 21
             }
           },
           "metadata": {
-            "polymer": {}
+            "polymer": {
+              "notify": true,
+              "observer": "\"_setListObjects\""
+            }
+          }
+        },
+        {
+          "name": "lists",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 169,
+              "column": 20
+            },
+            "end": {
+              "line": 172,
+              "column": 21
+            }
           },
-          "defaultValue": "{}"
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
         },
         {
           "name": "autoValidate",
@@ -206,11 +229,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 158,
+              "line": 176,
               "column": 20
             },
             "end": {
-              "line": 161,
+              "line": 179,
               "column": 21
             }
           },
@@ -226,11 +249,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 183,
               "column": 20
             },
             "end": {
-              "line": 168,
+              "line": 186,
               "column": 21
             }
           },
@@ -246,11 +269,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 176,
+              "line": 194,
               "column": 20
             },
             "end": {
-              "line": 179,
+              "line": 197,
               "column": 21
             }
           },
@@ -266,11 +289,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 187,
+              "line": 205,
               "column": 20
             },
             "end": {
-              "line": 190,
+              "line": 208,
               "column": 21
             }
           },
@@ -282,21 +305,62 @@
       ],
       "methods": [
         {
+          "name": "_setListObjects",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 212,
+              "column": 12
+            },
+            "end": {
+              "line": 222,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "data"
+            }
+          ]
+        },
+        {
           "name": "validate",
           "description": "Diese Methode validiert das Formular. Sie kann von\n'aussen' aufgerufen werden.",
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 198,
-              "column": 13
+              "line": 228,
+              "column": 12
             },
             "end": {
-              "line": 201,
+              "line": 231,
               "column": 13
             }
           },
           "metadata": {},
           "params": []
+        },
+        {
+          "name": "translate",
+          "description": "Methode ist nötig, da im Text Binding keine String-Concatenation möglich ist.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 237,
+              "column": 12
+            },
+            "end": {
+              "line": 240,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "return": {
+            "desc": "die übergebenen Parameter werden konkateniert und dann als Key für die Übersetzung genommen"
+          }
         }
       ],
       "staticMethods": [],
@@ -304,11 +368,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 141,
+          "line": 154,
           "column": 8
         },
         "end": {
-          "line": 202,
+          "line": 242,
           "column": 9
         }
       },
@@ -321,11 +385,27 @@
           "description": "Das Nutzdatenobjekt.",
           "sourceRange": {
             "start": {
-              "line": 149,
+              "line": 164,
               "column": 20
             },
             "end": {
-              "line": 154,
+              "line": 168,
+              "column": 21
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "lists",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 169,
+              "column": 20
+            },
+            "end": {
+              "line": 172,
               "column": 21
             }
           },
@@ -337,11 +417,11 @@
           "description": "Soll das Formular automatisch validiert werden?",
           "sourceRange": {
             "start": {
-              "line": 158,
+              "line": 176,
               "column": 20
             },
             "end": {
-              "line": 161,
+              "line": 179,
               "column": 21
             }
           },
@@ -353,11 +433,11 @@
           "description": "Soll das Formular nur lesend dargestellt werden?",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 183,
               "column": 20
             },
             "end": {
-              "line": 168,
+              "line": 186,
               "column": 21
             }
           },
@@ -365,7 +445,20 @@
           "type": "boolean"
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "data-changed",
+          "description": "Fired when the `data` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "lists-changed",
+          "description": "Fired when the `lists` property changes.",
+          "metadata": {}
+        }
+      ],
       "styling": {
         "cssVariables": [],
         "selectors": []
@@ -385,11 +478,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 93,
+              "line": 109,
               "column": 21
             },
             "end": {
-              "line": 96,
+              "line": 112,
               "column": 21
             }
           },
@@ -405,11 +498,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 104,
+              "line": 120,
               "column": 20
             },
             "end": {
-              "line": 107,
+              "line": 123,
               "column": 21
             }
           },
@@ -425,11 +518,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 81,
+          "line": 97,
           "column": 8
         },
         "end": {
-          "line": 120,
+          "line": 136,
           "column": 9
         }
       },
@@ -457,11 +550,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 117,
               "column": 20
             },
             "end": {
-              "line": 106,
+              "line": 120,
               "column": 21
             }
           },
@@ -477,11 +570,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 114,
+              "line": 128,
               "column": 21
             },
             "end": {
-              "line": 117,
+              "line": 131,
               "column": 21
             }
           },
@@ -497,11 +590,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 125,
+              "line": 139,
               "column": 20
             },
             "end": {
-              "line": 128,
+              "line": 142,
               "column": 21
             }
           },
@@ -517,11 +610,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 88,
+          "line": 102,
           "column": 8
         },
         "end": {
-          "line": 141,
+          "line": 155,
           "column": 9
         }
       },
@@ -534,11 +627,11 @@
           "description": "Das *UpdateForm kann auch lesend benutzt werden. Dazu muss\ndas Property 'readform' auf true gesetzt werden. Der \nDefault Wert ist immer 'false'. \n\nWird dieser Wert auf 'true' gesetzt, so sind die Felder des \nFormulars nicht mehr editierbar. Die Schaltflächen zum Editieren\nwerden ausgeblendet. Je nach Berechtigung wird eine Schaltfläche\nhinzugefügt, die das Formular wieder editierbar macht.",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 117,
               "column": 20
             },
             "end": {
-              "line": 106,
+              "line": 120,
               "column": 21
             }
           },
@@ -557,7 +650,7 @@
     {
       "description": "GENERATOR for all lists the same\n\n`animad-list-header` wird in den Listen als Header der Animad-Applikation angezeigt.\n\nDas Element bietet die Möglichkeit Suche- und Filter-Eingaben für die Liste zu setzen,\nselektierbare Filter anzuzeigen und\nEvents zur Navigation auf Formular-Seiten und zur Ausführung von Lösch- und Suchfunktionen anzustossen.\n\n#### Beispiel:\n\n    <animad-list-header\n        id=\"animad-list-header-filter\"\n        placeholder-search=\"[[t('filter_placeholder')]]\"\n        placeholder-delete=\"Löschen\"\n        placeholder-new=\"Neu\"\n        all-filters=\"[[_localizedFilters]]\"\n        selected-filters = \"{{_selectedFilters}}\"\n        search=\"{{_filterString}}\"\n        on-filter=\"_filterData\"\n        on-filter-selection=\"_filterSelectionData\"\n        on-delete=\"_confirmDeleteSelected\"\n        on-new=\"_handleNew\"\n        disable-delete-button=\"[[_disableDeleteButton]]\"\n        hide-header=\"[[_hideFilterHeader(hideHeader)]]\"\n        hide-new-button=\"[[hideNew]]\"\n        hide-delete-button=\"[[hideDelete]]\"\n        hide-filter-button=\"[[hideFilter]]\"\n        disable-filter-button=\"[[disableFilter]]\"\n        disable-new-button=\"[[disableNew]]\"\n        show-results=\"[[showResults]]\"\n        results-text=\"[[_resultsText]]\"\n        icon=\"[[icon]]\">\n    </animad-list-header>",
       "summary": "",
-      "path": "src/animad-keeper/animad-list-header.html",
+      "path": "src/common-libs/animad-list-header.html",
       "properties": [
         {
           "name": "__serializing",
@@ -4969,11 +5062,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
               "column": 15
             }
           },
@@ -4984,18 +5077,18 @@
           "inheritedFrom": "AnimadListBehavior"
         },
         {
-          "name": "_filteredData",
+          "name": "filteredData",
           "type": "Array",
-          "description": "_filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus _filteredData an.",
-          "privacy": "protected",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "privacy": "public",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 26,
+              "line": 36,
               "column": 14
             },
             "end": {
-              "line": 31,
+              "line": 41,
               "column": 15
             }
           },
@@ -5012,11 +5105,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 36,
+              "line": 46,
               "column": 14
             },
             "end": {
-              "line": 41,
+              "line": 51,
               "column": 15
             }
           },
@@ -5034,11 +5127,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -5055,11 +5148,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 81,
+              "line": 91,
               "column": 14
             },
             "end": {
-              "line": 83,
+              "line": 93,
               "column": 15
             }
           },
@@ -5076,11 +5169,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 87,
+              "line": 97,
               "column": 14
             },
             "end": {
-              "line": 92,
+              "line": 102,
               "column": 15
             }
           },
@@ -5098,11 +5191,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 96,
+              "line": 106,
               "column": 14
             },
             "end": {
-              "line": 98,
+              "line": 108,
               "column": 15
             }
           },
@@ -5119,11 +5212,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -5141,11 +5234,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 109,
+              "line": 119,
               "column": 14
             },
             "end": {
-              "line": 112,
+              "line": 122,
               "column": 15
             }
           },
@@ -5163,11 +5256,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 116,
+              "line": 126,
               "column": 14
             },
             "end": {
-              "line": 119,
+              "line": 129,
               "column": 15
             }
           },
@@ -5185,11 +5278,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 125,
+              "line": 135,
               "column": 14
             },
             "end": {
-              "line": 128,
+              "line": 138,
               "column": 15
             }
           },
@@ -5207,11 +5300,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 134,
+              "line": 144,
               "column": 14
             },
             "end": {
-              "line": 137,
+              "line": 147,
               "column": 15
             }
           },
@@ -5229,11 +5322,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 141,
+              "line": 151,
               "column": 14
             },
             "end": {
-              "line": 146,
+              "line": 156,
               "column": 15
             }
           },
@@ -5251,11 +5344,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 148,
+              "line": 158,
               "column": 14
             },
             "end": {
-              "line": 151,
+              "line": 161,
               "column": 15
             }
           },
@@ -5274,11 +5367,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -5296,11 +5389,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -5318,11 +5411,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -5340,11 +5433,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -5362,11 +5455,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -5384,11 +5477,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -5406,11 +5499,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -5428,11 +5521,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -5450,11 +5543,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -5472,11 +5565,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -5494,11 +5587,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -5515,11 +5608,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -5536,11 +5629,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -5558,11 +5651,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -5580,11 +5673,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -5602,11 +5695,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 282,
+              "line": 292,
               "column": 14
             },
             "end": {
-              "line": 284,
+              "line": 294,
               "column": 15
             }
           },
@@ -5623,11 +5716,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 288,
+              "line": 298,
               "column": 14
             },
             "end": {
-              "line": 291,
+              "line": 301,
               "column": 15
             }
           },
@@ -5645,11 +5738,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 296,
+              "line": 306,
               "column": 14
             },
             "end": {
-              "line": 299,
+              "line": 309,
               "column": 15
             }
           },
@@ -5667,11 +5760,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 303,
+              "line": 313,
               "column": 14
             },
             "end": {
-              "line": 306,
+              "line": 316,
               "column": 15
             }
           },
@@ -5689,11 +5782,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 310,
+              "line": 320,
               "column": 14
             },
             "end": {
-              "line": 312,
+              "line": 322,
               "column": 15
             }
           },
@@ -5814,11 +5907,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 326,
+              "line": 336,
               "column": 8
             },
             "end": {
-              "line": 329,
+              "line": 339,
               "column": 9
             }
           },
@@ -5833,11 +5926,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 336,
+              "line": 346,
               "column": 8
             },
             "end": {
-              "line": 366,
+              "line": 376,
               "column": 9
             }
           },
@@ -5850,17 +5943,36 @@
           "inheritedFrom": "AnimadListBehavior"
         },
         {
+          "name": "_onFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../behaviors/animad-list-behavior.html",
+            "start": {
+              "line": 378,
+              "column": 8
+            },
+            "end": {
+              "line": 384,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "AnimadListBehavior"
+        },
+        {
           "name": "_deselectItems",
           "description": "Deselektiert alle Datensätze",
           "privacy": "protected",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 371,
+              "line": 389,
               "column": 8
             },
             "end": {
-              "line": 379,
+              "line": 397,
               "column": 9
             }
           },
@@ -5879,11 +5991,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 385,
+              "line": 403,
               "column": 8
             },
             "end": {
-              "line": 387,
+              "line": 405,
               "column": 9
             }
           },
@@ -5902,11 +6014,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 393,
+              "line": 411,
               "column": 8
             },
             "end": {
-              "line": 395,
+              "line": 413,
               "column": 9
             }
           },
@@ -5925,11 +6037,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 402,
+              "line": 420,
               "column": 8
             },
             "end": {
-              "line": 404,
+              "line": 422,
               "column": 9
             }
           },
@@ -5948,11 +6060,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 410,
+              "line": 428,
               "column": 8
             },
             "end": {
-              "line": 433,
+              "line": 451,
               "column": 9
             }
           },
@@ -5974,11 +6086,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 440,
+              "line": 458,
               "column": 8
             },
             "end": {
-              "line": 452,
+              "line": 470,
               "column": 9
             }
           },
@@ -5993,11 +6105,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 457,
+              "line": 475,
               "column": 8
             },
             "end": {
-              "line": 462,
+              "line": 480,
               "column": 9
             }
           },
@@ -6016,11 +6128,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 469,
+              "line": 487,
               "column": 8
             },
             "end": {
-              "line": 492,
+              "line": 511,
               "column": 9
             }
           },
@@ -6039,11 +6151,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 498,
+              "line": 517,
               "column": 8
             },
             "end": {
-              "line": 517,
+              "line": 536,
               "column": 9
             }
           },
@@ -6062,11 +6174,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 523,
+              "line": 542,
               "column": 8
             },
             "end": {
-              "line": 539,
+              "line": 558,
               "column": 9
             }
           },
@@ -6102,11 +6214,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 563,
+              "line": 582,
               "column": 8
             },
             "end": {
-              "line": 572,
+              "line": 591,
               "column": 9
             }
           },
@@ -6121,11 +6233,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 577,
+              "line": 596,
               "column": 8
             },
             "end": {
-              "line": 580,
+              "line": 599,
               "column": 9
             }
           },
@@ -6140,11 +6252,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 586,
+              "line": 605,
               "column": 8
             },
             "end": {
-              "line": 615,
+              "line": 635,
               "column": 9
             }
           },
@@ -6161,16 +6273,16 @@
         },
         {
           "name": "_transferCellnameToFieldname",
-          "description": "Wandelt den tabellennamen in den korrespondierenden Backend-Feldnamen um",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 620,
+              "line": 637,
               "column": 8
             },
             "end": {
-              "line": 642,
+              "line": 657,
               "column": 9
             }
           },
@@ -6192,11 +6304,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 648,
+              "line": 663,
               "column": 8
             },
             "end": {
-              "line": 657,
+              "line": 673,
               "column": 9
             }
           },
@@ -6215,11 +6327,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 662,
+              "line": 678,
               "column": 8
             },
             "end": {
-              "line": 688,
+              "line": 705,
               "column": 9
             }
           },
@@ -6238,11 +6350,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 702,
+              "line": 719,
               "column": 8
             },
             "end": {
-              "line": 706,
+              "line": 723,
               "column": 9
             }
           },
@@ -6264,11 +6376,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 711,
+              "line": 728,
               "column": 8
             },
             "end": {
-              "line": 715,
+              "line": 732,
               "column": 9
             }
           },
@@ -6290,11 +6402,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 720,
+              "line": 737,
               "column": 8
             },
             "end": {
-              "line": 724,
+              "line": 741,
               "column": 9
             }
           },
@@ -6462,47 +6574,6 @@
               "name": "event"
             }
           ]
-        },
-        {
-          "name": "_filter",
-          "description": "Filtert die gefundenen Datensätze nach dem eingegebenen String im Filter-Feld.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 314,
-              "column": 8
-            },
-            "end": {
-              "line": 324,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_useSelectedFilters",
-          "description": "Filtert die gefundenen Datensätze nach den ausgewählten, selektierbaren Filtern.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 329,
-              "column": 8
-            },
-            "end": {
-              "line": 336,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "keeper"
-            },
-            {
-              "name": "event"
-            }
-          ]
         }
       ],
       "staticMethods": [],
@@ -6514,7 +6585,7 @@
           "column": 6
         },
         "end": {
-          "line": 338,
+          "line": 311,
           "column": 7
         }
       },
@@ -6528,11 +6599,29 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
+              "column": 15
+            }
+          },
+          "metadata": {},
+          "type": "Array",
+          "inheritedFrom": "AnimadListBehavior"
+        },
+        {
+          "name": "filtered-data",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "sourceRange": {
+            "file": "../behaviors/animad-list-behavior.html",
+            "start": {
+              "line": 36,
+              "column": 14
+            },
+            "end": {
+              "line": 41,
               "column": 15
             }
           },
@@ -6546,11 +6635,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -6564,11 +6653,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -6582,11 +6671,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -6600,11 +6689,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -6618,11 +6707,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -6636,11 +6725,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -6654,11 +6743,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -6672,11 +6761,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -6690,11 +6779,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -6708,11 +6797,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -6726,11 +6815,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -6744,11 +6833,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -6762,11 +6851,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -6780,11 +6869,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -6798,11 +6887,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -6816,11 +6905,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -6834,11 +6923,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -6883,7 +6972,15 @@
           "inheritedFrom": "AnimadI18nBehavior"
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "filter-data",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "metadata": {},
+          "inheritedFrom": "AnimadListBehavior"
+        }
+      ],
       "styling": {
         "cssVariables": [],
         "selectors": []
@@ -7574,11 +7671,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 80,
               "column": 14
             },
             "end": {
-              "line": 71,
+              "line": 80,
               "column": 30
             }
           },
@@ -7662,11 +7759,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 68,
               "column": 14
             },
             "end": {
-              "line": 62,
+              "line": 71,
               "column": 15
             }
           },
@@ -7681,11 +7778,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 72,
               "column": 14
             },
             "end": {
-              "line": 66,
+              "line": 75,
               "column": 15
             }
           },
@@ -7700,11 +7797,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 76,
               "column": 14
             },
             "end": {
-              "line": 67,
+              "line": 76,
               "column": 31
             }
           },
@@ -7719,17 +7816,56 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 77,
               "column": 14
             },
             "end": {
-              "line": 68,
+              "line": 77,
               "column": 30
             }
           },
           "metadata": {
             "polymer": {}
           }
+        },
+        {
+          "name": "backendUrl",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 81,
+              "column": 14
+            },
+            "end": {
+              "line": 83,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_filteredData",
+          "type": "Array",
+          "description": "_filteredData enthält alle Objekte, die auf eingegebene oder ausgewählte Filter zutreffen.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 87,
+              "column": 14
+            },
+            "end": {
+              "line": 92,
+              "column": 15
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
         }
       ],
       "methods": [
@@ -9736,11 +9872,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 102,
               "column": 8
             },
             "end": {
-              "line": 83,
+              "line": 104,
               "column": 9
             }
           },
@@ -9748,6 +9884,27 @@
           "params": [
             {
               "name": "page"
+            }
+          ]
+        },
+        {
+          "name": "_filterData",
+          "description": "Wird ausgelöst durch den Event (TBD).\nFiltert die Daten der Liste. Der `event` enthält die folgenden Informationen:\nevent.detail.filteredData:    Die gefilterten Daten der Liste\nevent.detail.filtersSelected: Die selektierten Filter\nevent.detail.filterString:    Die Eingabe im Filter-Feld",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 113,
+              "column": 8
+            },
+            "end": {
+              "line": 132,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
             }
           ]
         }
@@ -10552,11 +10709,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 53,
+          "line": 62,
           "column": 4
         },
         "end": {
-          "line": 84,
+          "line": 133,
           "column": 5
         }
       },
@@ -10569,11 +10726,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 59,
+              "line": 68,
               "column": 14
             },
             "end": {
-              "line": 62,
+              "line": 71,
               "column": 15
             }
           },
@@ -10585,11 +10742,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 63,
+              "line": 72,
               "column": 14
             },
             "end": {
-              "line": 66,
+              "line": 75,
               "column": 15
             }
           },
@@ -10601,11 +10758,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 67,
+              "line": 76,
               "column": 14
             },
             "end": {
-              "line": 67,
+              "line": 76,
               "column": 31
             }
           },
@@ -10617,11 +10774,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 68,
+              "line": 77,
               "column": 14
             },
             "end": {
-              "line": 68,
+              "line": 77,
               "column": 30
             }
           },
@@ -10633,12 +10790,28 @@
           "description": "Polymer.Element#rootPath",
           "sourceRange": {
             "start": {
-              "line": 71,
+              "line": 80,
               "column": 14
             },
             "end": {
-              "line": 71,
+              "line": 80,
               "column": 30
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "backend-url",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 81,
+              "column": 14
+            },
+            "end": {
+              "line": 83,
+              "column": 15
             }
           },
           "metadata": {},
@@ -10654,4378 +10827,6 @@
       "tagname": "animad-keepers-view"
     },
     {
-      "description": "",
-      "summary": "",
-      "path": "src/animad-animal/animad-list-header.html",
-      "properties": [
-        {
-          "name": "__serializing",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 125,
-              "column": 8
-            },
-            "end": {
-              "line": 125,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataCounter",
-          "type": "number",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1171,
-              "column": 8
-            },
-            "end": {
-              "line": 1171,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataEnabled",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 129,
-              "column": 8
-            },
-            "end": {
-              "line": 129,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataReady",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 131,
-              "column": 8
-            },
-            "end": {
-              "line": 131,
-              "column": 25
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataInvalid",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 133,
-              "column": 8
-            },
-            "end": {
-              "line": 133,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__data",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1153,
-              "column": 8
-            },
-            "end": {
-              "line": 1153,
-              "column": 20
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataPending",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1155,
-              "column": 8
-            },
-            "end": {
-              "line": 1155,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataOld",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1157,
-              "column": 8
-            },
-            "end": {
-              "line": 1157,
-              "column": 23
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataProto",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 141,
-              "column": 8
-            },
-            "end": {
-              "line": 141,
-              "column": 25
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataHasAccessor",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 143,
-              "column": 8
-            },
-            "end": {
-              "line": 143,
-              "column": 31
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataInstanceProps",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 145,
-              "column": 8
-            },
-            "end": {
-              "line": 145,
-              "column": 33
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataClientsReady",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1135,
-              "column": 8
-            },
-            "end": {
-              "line": 1135,
-              "column": 32
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataPendingClients",
-          "type": "Array",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1137,
-              "column": 8
-            },
-            "end": {
-              "line": 1137,
-              "column": 34
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataToNotify",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1139,
-              "column": 8
-            },
-            "end": {
-              "line": 1139,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataLinkedPaths",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1141,
-              "column": 8
-            },
-            "end": {
-              "line": 1141,
-              "column": 31
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataHasPaths",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1143,
-              "column": 8
-            },
-            "end": {
-              "line": 1143,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataCompoundStorage",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1145,
-              "column": 8
-            },
-            "end": {
-              "line": 1145,
-              "column": 35
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataHost",
-          "type": "Polymer_PropertyEffects",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1147,
-              "column": 8
-            },
-            "end": {
-              "line": 1147,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataTemp",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1149,
-              "column": 8
-            },
-            "end": {
-              "line": 1149,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataClientsInitialized",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1151,
-              "column": 8
-            },
-            "end": {
-              "line": 1151,
-              "column": 38
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__computeEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1159,
-              "column": 8
-            },
-            "end": {
-              "line": 1159,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__reflectEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1161,
-              "column": 8
-            },
-            "end": {
-              "line": 1161,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__notifyEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1163,
-              "column": 8
-            },
-            "end": {
-              "line": 1163,
-              "column": 29
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__propagateEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1165,
-              "column": 8
-            },
-            "end": {
-              "line": 1165,
-              "column": 32
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__observeEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1167,
-              "column": 8
-            },
-            "end": {
-              "line": 1167,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__readOnly",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1169,
-              "column": 8
-            },
-            "end": {
-              "line": 1169,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__templateInfo",
-          "type": "!TemplateInfo",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1173,
-              "column": 8
-            },
-            "end": {
-              "line": 1173,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_template",
-          "type": "HTMLTemplateElement",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 560,
-              "column": 8
-            },
-            "end": {
-              "line": 560,
-              "column": 23
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_importPath",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 562,
-              "column": 8
-            },
-            "end": {
-              "line": 562,
-              "column": 25
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "rootPath",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 564,
-              "column": 8
-            },
-            "end": {
-              "line": 564,
-              "column": 22
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "importPath",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 566,
-              "column": 8
-            },
-            "end": {
-              "line": 566,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "root",
-          "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 568,
-              "column": 8
-            },
-            "end": {
-              "line": 568,
-              "column": 18
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "$",
-          "type": "!Object.<string, !Element>",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 570,
-              "column": 8
-            },
-            "end": {
-              "line": 570,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "search",
-          "type": "string",
-          "description": "Query for which the user was searching",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 72,
-              "column": 11
-            },
-            "end": {
-              "line": 76,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "notify": true,
-              "observer": "\"_onChangeRequest\""
-            }
-          }
-        },
-        {
-          "name": "selectedFilters",
-          "type": "Array",
-          "description": "selectedFilters enthält die Information über alle ausgewählten Filter.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 80,
-              "column": 14
-            },
-            "end": {
-              "line": 85,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "[]"
-        },
-        {
-          "name": "allFilters",
-          "type": "Object",
-          "description": "All filters from which the user can choose",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 11
-            },
-            "end": {
-              "line": 89,
-              "column": 29
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          }
-        },
-        {
-          "name": "hideHeader",
-          "type": "boolean",
-          "description": "Wether to hide the whole list header. Set attribute \"hide-header\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 93,
-              "column": 18
-            },
-            "end": {
-              "line": 93,
-              "column": 37
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          }
-        },
-        {
-          "name": "hideFilterButton",
-          "type": "boolean",
-          "description": "Whether to hide the Filter button. Set attribute \"hide-filter-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 97,
-              "column": 11
-            },
-            "end": {
-              "line": 100,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "hideDeleteButton",
-          "type": "boolean",
-          "description": "Whether to hide the Delete button. Set attribute \"hide-delete-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 104,
-              "column": 11
-            },
-            "end": {
-              "line": 107,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "hideNewButton",
-          "type": "boolean",
-          "description": "Whether to hide the New button. Set attribute \"hide-new-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 111,
-              "column": 11
-            },
-            "end": {
-              "line": 114,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "disableFilterButton",
-          "type": "boolean",
-          "description": "Whether to disable the Filter button. Set attribute \"disable-filter-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 118,
-              "column": 11
-            },
-            "end": {
-              "line": 121,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "disableDeleteButton",
-          "type": "boolean",
-          "description": "Whether to disable the Delete button. Set attribute \"disable-delete-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 125,
-              "column": 11
-            },
-            "end": {
-              "line": 128,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "disableNewButton",
-          "type": "boolean",
-          "description": "Whether to disable the New button. Set attribute \"disable-new-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 132,
-              "column": 11
-            },
-            "end": {
-              "line": 135,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "icon",
-          "type": "string",
-          "description": "Icon shown in the search background",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 139,
-              "column": 11
-            },
-            "end": {
-              "line": 142,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"search\""
-        },
-        {
-          "name": "placeholderSearch",
-          "type": "string",
-          "description": "Text shown in the search box if the user didn't enter any query",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 146,
-              "column": 11
-            },
-            "end": {
-              "line": 149,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"Search\""
-        },
-        {
-          "name": "placeholderDelete",
-          "type": "string",
-          "description": "Text for Delete button if the user didn't enter any query",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 153,
-              "column": 11
-            },
-            "end": {
-              "line": 156,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"Delete\""
-        },
-        {
-          "name": "placeholderNew",
-          "type": "string",
-          "description": "Text for New button if the user didn't enter any query",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 160,
-              "column": 11
-            },
-            "end": {
-              "line": 163,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"New\""
-        },
-        {
-          "name": "_isFilterSelectionOpen",
-          "type": "boolean",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 167,
-              "column": 14
-            },
-            "end": {
-              "line": 170,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "showResults",
-          "type": "boolean",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 174,
-              "column": 14
-            },
-            "end": {
-              "line": 177,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "true"
-        },
-        {
-          "name": "resultsText",
-          "type": "string",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 181,
-              "column": 14
-            },
-            "end": {
-              "line": 184,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"\""
-        }
-      ],
-      "methods": [
-        {
-          "name": "_stampTemplate",
-          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2366,
-              "column": 6
-            },
-            "end": {
-              "line": 2391,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template to stamp"
-            }
-          ],
-          "return": {
-            "type": "!StampedTemplate",
-            "desc": "Cloned template content"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_addMethodEventListenerToNode",
-          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 452,
-              "column": 6
-            },
-            "end": {
-              "line": 457,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to add listener on"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "methodName",
-              "type": "string",
-              "description": "Name of method"
-            },
-            {
-              "name": "context",
-              "type": "*=",
-              "description": "Context the method will be called on (defaults\n  to `node`)"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "Generated handler function"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_addEventListenerToNode",
-          "description": "Override point for adding custom or simulated event handling.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 467,
-              "column": 6
-            },
-            "end": {
-              "line": 469,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to add event listener to"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "handler",
-              "type": "Function",
-              "description": "Listener function to add"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_removeEventListenerFromNode",
-          "description": "Override point for adding custom or simulated event handling.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 479,
-              "column": 6
-            },
-            "end": {
-              "line": 481,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to remove event listener from"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "handler",
-              "type": "Function",
-              "description": "Listener function to remove"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "attributeChangedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialized to \"camelCase\"\nproperties.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 754,
-              "column": 6
-            },
-            "end": {
-              "line": 762,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of attribute."
-            },
-            {
-              "name": "old",
-              "type": "?string",
-              "description": "Old value of attribute."
-            },
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "Current value of attribute."
-            }
-          ],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_initializeProperties",
-          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 584,
-              "column": 6
-            },
-            "end": {
-              "line": 618,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_initializeProtoProperties",
-          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1203,
-              "column": 6
-            },
-            "end": {
-              "line": 1207,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Properties to initialize on the prototype"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_initializeInstanceProperties",
-          "description": "Overrides `Polymer.PropertyAccessors` implementation to avoid setting\n`_setProperty`'s `shouldNotify: true`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1216,
-              "column": 6
-            },
-            "end": {
-              "line": 1225,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Properties to initialize on the instance"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_ensureAttribute",
-          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 242,
-              "column": 6
-            },
-            "end": {
-              "line": 246,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Name of attribute to ensure is set."
-            },
-            {
-              "name": "value",
-              "type": "string",
-              "description": "of the attribute."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_attributeToProperty",
-          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 259,
-              "column": 6
-            },
-            "end": {
-              "line": 265,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Name of attribute to deserialize."
-            },
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "of the attribute."
-            },
-            {
-              "name": "type",
-              "type": "*=",
-              "description": "type to deserialize to."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_propertyToAttribute",
-          "description": "Serializes a property to its associated attribute.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 275,
-              "column": 6
-            },
-            "end": {
-              "line": 281,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name to reflect."
-            },
-            {
-              "name": "attribute",
-              "type": "string=",
-              "description": "Attribute name to reflect."
-            },
-            {
-              "name": "value",
-              "type": "*=",
-              "description": "Property value to refect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_valueToNodeAttribute",
-          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 296,
-              "column": 6
-            },
-            "end": {
-              "line": 303,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Element to set attribute to."
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to serialize."
-            },
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Attribute name to serialize to."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_serializeValue",
-          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called by Polymer when setting JS property values to\nHTML attributes.  Users may override this method on Polymer element\nprototypes to provide serialization for custom types.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 315,
-              "column": 6
-            },
-            "end": {
-              "line": 335,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Property value to serialize."
-            }
-          ],
-          "return": {
-            "type": "(string|undefined)",
-            "desc": "String serialized from the provided property value."
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_deserializeValue",
-          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called by Polymer when reading HTML attribute values to\nJS properties.  Users may override this method on Polymer element\nprototypes to provide deserialization for custom `type`s.  Note,\nthe `type` argument is the value of the `type` field provided in the\n`properties` configuration object for a given property, and is\nby convention the constructor for the type to deserialize.\n\nNote: The return value of `undefined` is used as a sentinel value to\nindicate the attribute should be removed.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 354,
-              "column": 6
-            },
-            "end": {
-              "line": 397,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "Attribute value to deserialize."
-            },
-            {
-              "name": "type",
-              "type": "*=",
-              "description": "Type to deserialize the string to."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Typed value deserialized from the provided string."
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_createPropertyAccessor",
-          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.  When calling on\na prototype, any overwritten values are saved in `__dataProto`,\nand it is up to the subclasser to decide how/when to set those\nproperties back into the accessor.  When calling on an instance,\nthe overwritten value is set via `_setPendingProperty`, and the\nuser should call `_invalidateProperties` or `_flushProperties`\nfor the values to take effect.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 422,
-              "column": 6
-            },
-            "end": {
-              "line": 442,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "readOnly",
-              "type": "boolean=",
-              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_hasAccessor",
-          "description": "Returns true if this library created an accessor for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 450,
-              "column": 6
-            },
-            "end": {
-              "line": 452,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if an accessor was created"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_setProperty",
-          "description": "Overrides base implementation to ensure all accessors set `shouldNotify`\nto true, for per-property notification tracking.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1495,
-              "column": 6
-            },
-            "end": {
-              "line": 1499,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property"
-            },
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setPendingProperty",
-          "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChanged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1458,
-              "column": 6
-            },
-            "end": {
-              "line": 1487,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set"
-            },
-            {
-              "name": "shouldNotify",
-              "type": "boolean=",
-              "description": "True if property should fire notification\n  event (applies only for `notify: true` properties)"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Returns true if the property changed"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_isPropertyPending",
-          "description": "Returns true if the specified property has a pending change.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 505,
-              "column": 6
-            },
-            "end": {
-              "line": 507,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if property has a pending change"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_invalidateProperties",
-          "description": "Overrides `PropertyAccessor`'s default async queuing of\n`_propertiesChanged`: if `__dataReady` is false (has not yet been\nmanually flushed), the function no-ops; otherwise flushes\n`_propertiesChanged` synchronously.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1509,
-              "column": 6
-            },
-            "end": {
-              "line": 1513,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_enableProperties",
-          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 538,
-              "column": 6
-            },
-            "end": {
-              "line": 547,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_flushProperties",
-          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 558,
-              "column": 6
-            },
-            "end": {
-              "line": 566,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "ready",
-          "description": "Stamps the element template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 682,
-              "column": 6
-            },
-            "end": {
-              "line": 688,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_propertiesChanged",
-          "description": "Implements `PropertyAccessors`'s properties changed callback.\n\nRuns each class of effects for the batch of changed properties in\na specific order (compute, propagate, reflect, observe, notify).",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1652,
-              "column": 6
-            },
-            "end": {
-              "line": 1685,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "currentProps"
-            },
-            {
-              "name": "changedProps"
-            },
-            {
-              "name": "oldProps"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_shouldPropertyChange",
-          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` for primitive types if a\nstrict equality check fails, and returns `true` for all Object/Arrays.\nThe method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 621,
-              "column": 6
-            },
-            "end": {
-              "line": 624,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "New property value"
-            },
-            {
-              "name": "old",
-              "type": "*",
-              "description": "Previous property value"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Whether the property should be considered a change\n  and enqueue a `_propertiesChanged` callback"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_addPropertyEffect",
-          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1240,
-              "column": 6
-            },
-            "end": {
-              "line": 1248,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_removePropertyEffect",
-          "description": "Removes the given property effect.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1258,
-              "column": 6
-            },
-            "end": {
-              "line": 1264,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property the effect was associated with"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object to remove"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasPropertyEffect",
-          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1275,
-              "column": 6
-            },
-            "end": {
-              "line": 1278,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "type",
-              "type": "string=",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasReadOnlyEffect",
-          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1288,
-              "column": 6
-            },
-            "end": {
-              "line": 1290,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasNotifyEffect",
-          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1300,
-              "column": 6
-            },
-            "end": {
-              "line": 1302,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasReflectEffect",
-          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1312,
-              "column": 6
-            },
-            "end": {
-              "line": 1314,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasComputedEffect",
-          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1324,
-              "column": 6
-            },
-            "end": {
-              "line": 1326,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setPendingPropertyOrPath",
-          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1358,
-              "column": 6
-            },
-            "end": {
-              "line": 1390,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(number|string)>)",
-              "description": "Path to set"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set"
-            },
-            {
-              "name": "shouldNotify",
-              "type": "boolean=",
-              "description": "Set to true if this change should\n cause a property notification event dispatch"
-            },
-            {
-              "name": "isPathNotification",
-              "type": "boolean=",
-              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setUnmanagedPropertyToNode",
-          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1413,
-              "column": 6
-            },
-            "end": {
-              "line": 1421,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "The node to set a property on"
-            },
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "The property to set"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "The value to set"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_enqueueClient",
-          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1524,
-              "column": 6
-            },
-            "end": {
-              "line": 1529,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "client",
-              "type": "Object",
-              "description": "PropertyEffects client to enqueue"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_flushClients",
-          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1538,
-              "column": 6
-            },
-            "end": {
-              "line": 1549,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__enableOrFlushClients",
-          "description": "(c) the stamped dom enables.",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1563,
-              "column": 6
-            },
-            "end": {
-              "line": 1576,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_readyClients",
-          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 699,
-              "column": 6
-            },
-            "end": {
-              "line": 708,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "setProperties",
-          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1605,
-              "column": 6
-            },
-            "end": {
-              "line": 1616,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
-            },
-            {
-              "name": "setReadOnly",
-              "type": "boolean=",
-              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_propagatePropertyChanges",
-          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1697,
-              "column": 6
-            },
-            "end": {
-              "line": 1707,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changedProps",
-              "type": "Object",
-              "description": "Bag of changed properties"
-            },
-            {
-              "name": "oldProps",
-              "type": "Object",
-              "description": "Bag of previous values for changed properties"
-            },
-            {
-              "name": "hasPaths",
-              "type": "boolean",
-              "description": "True with `props` contains one or more paths"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "linkPaths",
-          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1718,
-              "column": 6
-            },
-            "end": {
-              "line": 1723,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "to",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Target path to link."
-            },
-            {
-              "name": "from",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Source path to link."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "unlinkPaths",
-          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1735,
-              "column": 6
-            },
-            "end": {
-              "line": 1740,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Target path to unlink."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "notifySplices",
-          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1772,
-              "column": 6
-            },
-            "end": {
-              "line": 1776,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Path that should be notified."
-            },
-            {
-              "name": "splices",
-              "type": "Array",
-              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "get",
-          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1797,
-              "column": 6
-            },
-            "end": {
-              "line": 1799,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
-            },
-            {
-              "name": "root",
-              "type": "Object=",
-              "description": "Root object from which the path is evaluated."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "set",
-          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1822,
-              "column": 6
-            },
-            "end": {
-              "line": 1832,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set at the specified path."
-            },
-            {
-              "name": "root",
-              "type": "Object=",
-              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "push",
-          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1848,
-              "column": 6
-            },
-            "end": {
-              "line": 1857,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to push onto array"
-            }
-          ],
-          "return": {
-            "type": "number",
-            "desc": "New length of the array."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "pop",
-          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1872,
-              "column": 6
-            },
-            "end": {
-              "line": 1881,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Item that was removed."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "splice",
-          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1900,
-              "column": 6
-            },
-            "end": {
-              "line": 1917,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "start",
-              "type": "number",
-              "description": "Index from which to start removing/inserting."
-            },
-            {
-              "name": "deleteCount",
-              "type": "number",
-              "description": "Number of items to remove."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to insert into array."
-            }
-          ],
-          "return": {
-            "type": "Array",
-            "desc": "Array of removed items."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "shift",
-          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1932,
-              "column": 6
-            },
-            "end": {
-              "line": 1941,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Item that was removed."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "unshift",
-          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1957,
-              "column": 6
-            },
-            "end": {
-              "line": 1965,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to insert info array"
-            }
-          ],
-          "return": {
-            "type": "number",
-            "desc": "New length of the array."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "notifyPath",
-          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1980,
-              "column": 6
-            },
-            "end": {
-              "line": 1997,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Path that should be notified."
-            },
-            {
-              "name": "value",
-              "type": "*=",
-              "description": "Value at the path (optional)."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createReadOnlyProperty",
-          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2010,
-              "column": 6
-            },
-            "end": {
-              "line": 2017,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "protectedSetter",
-              "type": "boolean=",
-              "description": "Creates a custom protected setter\n  when `true`."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createPropertyObserver",
-          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2031,
-              "column": 6
-            },
-            "end": {
-              "line": 2041,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "method",
-              "type": "(string|function (*, *))",
-              "description": "Function or name of observer method to call"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "boolean=",
-              "description": "Whether the method name should be included as\n  a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createMethodObserver",
-          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2054,
-              "column": 6
-            },
-            "end": {
-              "line": 2060,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createNotifyingProperty",
-          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2071,
-              "column": 6
-            },
-            "end": {
-              "line": 2079,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createReflectedProperty",
-          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2090,
-              "column": 6
-            },
-            "end": {
-              "line": 2103,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createComputedProperty",
-          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2117,
-              "column": 6
-            },
-            "end": {
-              "line": 2123,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of computed property to set"
-            },
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_bindTemplate",
-          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2300,
-              "column": 6
-            },
-            "end": {
-              "line": 2323,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "HTMLTemplateElement",
-              "description": "Template containing binding\n  bindings"
-            },
-            {
-              "name": "instanceBinding",
-              "type": "boolean=",
-              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
-            }
-          ],
-          "return": {
-            "type": "!TemplateInfo",
-            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_removeBoundDom",
-          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2402,
-              "column": 6
-            },
-            "end": {
-              "line": 2423,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "dom",
-              "type": "!StampedTemplate",
-              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "connectedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 664,
-              "column": 6
-            },
-            "end": {
-              "line": 669,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`disconnectedCallback`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 675,
-              "column": 6
-            },
-            "end": {
-              "line": 675,
-              "column": 31
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_attachDom",
-          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 722,
-              "column": 6
-            },
-            "end": {
-              "line": 738,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "dom",
-              "type": "StampedTemplate",
-              "description": "to attach to the element."
-            }
-          ],
-          "return": {
-            "type": "ShadowRoot",
-            "desc": "node to which the dom has been attached."
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "updateStyles",
-          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 782,
-              "column": 6
-            },
-            "end": {
-              "line": 786,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "properties",
-              "type": "Object=",
-              "description": "Bag of custom property key/values to\n  apply to this element."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "resolveUrl",
-          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 799,
-              "column": 6
-            },
-            "end": {
-              "line": 804,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "url",
-              "type": "string",
-              "description": "URL to resolve."
-            },
-            {
-              "name": "base",
-              "type": "string=",
-              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
-            }
-          ],
-          "return": {
-            "type": "string",
-            "desc": "Rewritten URL relative to base"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "attached",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 188,
-              "column": 12
-            },
-            "end": {
-              "line": 191,
-              "column": 13
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_onSearchRequest",
-          "description": "Private methods",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 194,
-              "column": 12
-            },
-            "end": {
-              "line": 196,
-              "column": 13
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_onChangeRequest",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 198,
-              "column": 7
-            },
-            "end": {
-              "line": 203,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "newValue"
-            },
-            {
-              "name": "oldValue"
-            }
-          ]
-        },
-        {
-          "name": "_onFilter",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 205,
-              "column": 9
-            },
-            "end": {
-              "line": 234,
-              "column": 10
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_onDelete",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 236,
-              "column": 9
-            },
-            "end": {
-              "line": 238,
-              "column": 10
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_onNew",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 239,
-              "column": 9
-            },
-            "end": {
-              "line": 241,
-              "column": 10
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_toggleFilterSelectionOpen",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 242,
-              "column": 9
-            },
-            "end": {
-              "line": 244,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_hideFilterButton",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 245,
-              "column": 9
-            },
-            "end": {
-              "line": 247,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filters"
-            }
-          ]
-        },
-        {
-          "name": "_disableFilterButton",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 248,
-              "column": 7
-            },
-            "end": {
-              "line": 250,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filters"
-            }
-          ]
-        }
-      ],
-      "staticMethods": [
-        {
-          "name": "_parseTemplate",
-          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 197,
-              "column": 6
-            },
-            "end": {
-              "line": 208,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template to parse"
-            },
-            {
-              "name": "outerTemplateInfo",
-              "type": "TemplateInfo=",
-              "description": "Template metadata from the outer\n  template, for parsing nested templates"
-            }
-          ],
-          "return": {
-            "type": "!TemplateInfo",
-            "desc": "Parsed template metadata"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateContent",
-          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 815,
-              "column": 6
-            },
-            "end": {
-              "line": 818,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template"
-            },
-            {
-              "name": "templateInfo"
-            },
-            {
-              "name": "nodeInfo"
-            }
-          ],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_parseTemplateNode",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2442,
-              "column": 6
-            },
-            "end": {
-              "line": 2456,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseTemplateChildNodes",
-          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 258,
-              "column": 6
-            },
-            "end": {
-              "line": 295,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "root",
-              "type": "Node",
-              "description": "Root node whose `childNodes` will be parsed"
-            },
-            {
-              "name": "templateInfo",
-              "type": "!TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "!NodeInfo",
-              "description": "Node metadata for current template."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateNestedTemplate",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2529,
-              "column": 6
-            },
-            "end": {
-              "line": 2539,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseTemplateNodeAttributes",
-          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 333,
-              "column": 6
-            },
-            "end": {
-              "line": 342,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template."
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateNodeAttribute",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2477,
-              "column": 6
-            },
-            "end": {
-              "line": 2513,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Attribute name"
-            },
-            {
-              "name": "value",
-              "type": "string",
-              "description": "Attribute value"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_contentForTemplate",
-          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 388,
-              "column": 6
-            },
-            "end": {
-              "line": 391,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "HTMLTemplateElement",
-              "description": "Template to retrieve `content` for"
-            }
-          ],
-          "return": {
-            "type": "DocumentFragment",
-            "desc": "Content fragment"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "createPropertiesForAttributes",
-          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 115,
-              "column": 6
-            },
-            "end": {
-              "line": 120,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "addPropertyEffect",
-          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2163,
-              "column": 6
-            },
-            "end": {
-              "line": 2165,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createPropertyObserver",
-          "description": "Creates a single-property observer for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2177,
-              "column": 6
-            },
-            "end": {
-              "line": 2179,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "method",
-              "type": "(string|function (*, *))",
-              "description": "Function or name of observer method to call"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "boolean=",
-              "description": "Whether the method name should be included as\n  a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createMethodObserver",
-          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2194,
-              "column": 6
-            },
-            "end": {
-              "line": 2196,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating"
-            }
-          ],
-          "return": {
-            "type": "void",
-            "desc": "whether method names should be included as a dependency to the effect."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createNotifyingProperty",
-          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2206,
-              "column": 6
-            },
-            "end": {
-              "line": 2208,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createReadOnlyProperty",
-          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2226,
-              "column": 6
-            },
-            "end": {
-              "line": 2228,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "protectedSetter",
-              "type": "boolean=",
-              "description": "Creates a custom protected setter\n  when `true`."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createReflectedProperty",
-          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2238,
-              "column": 6
-            },
-            "end": {
-              "line": 2240,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createComputedProperty",
-          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2256,
-              "column": 6
-            },
-            "end": {
-              "line": 2258,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of computed property to set"
-            },
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "bindTemplate",
-          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2272,
-              "column": 6
-            },
-            "end": {
-              "line": 2274,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "HTMLTemplateElement",
-              "description": "Template containing binding\n  bindings"
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "Template metadata object"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_addTemplatePropertyEffect",
-          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2338,
-              "column": 6
-            },
-            "end": {
-              "line": 2344,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateInfo",
-              "type": "Object",
-              "description": "Template metadata to add effect to"
-            },
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseBindings",
-          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2574,
-              "column": 6
-            },
-            "end": {
-              "line": 2639,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "text",
-              "type": "string",
-              "description": "Text to parse from attribute or textContent"
-            },
-            {
-              "name": "templateInfo",
-              "type": "Object",
-              "description": "Current template metadata"
-            }
-          ],
-          "return": {
-            "type": "Array.<!BindingPart>",
-            "desc": "Array of binding part metadata"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_evaluateBinding",
-          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2655,
-              "column": 6
-            },
-            "end": {
-              "line": 2672,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "inst",
-              "type": "this",
-              "description": "Element that should be used as scope for\n  binding dependencies"
-            },
-            {
-              "name": "part",
-              "type": "BindingPart",
-              "description": "Binding part metadata"
-            },
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Property/path that triggered this effect"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of current property changes"
-            },
-            {
-              "name": "oldProps",
-              "type": "Object",
-              "description": "Bag of previous values for changed properties"
-            },
-            {
-              "name": "hasPaths",
-              "type": "boolean",
-              "description": "True with `props` contains one or more paths"
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Value the binding part evaluated to"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "finalize",
-          "description": "Called automatically when the first element instance is created to\nensure that class finalization work has been completed.\nMay be called by users to eagerly perform class finalization work\nprior to the creation of the first element instance.\n\nClass finalization work generally includes meta-programming such as\ncreating property accessors and any property effect metadata needed for\nthe features used.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 482,
-              "column": 6
-            },
-            "end": {
-              "line": 486,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_processStyleText",
-          "description": "Gather style text for a style element in the template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 628,
-              "column": 6
-            },
-            "end": {
-              "line": 630,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cssText",
-              "type": "string",
-              "description": "Text containing styling to process"
-            },
-            {
-              "name": "baseURI",
-              "type": "string",
-              "description": "Base URI to rebase CSS paths against"
-            }
-          ],
-          "return": {
-            "type": "string",
-            "desc": "The processed CSS text"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_finalizeTemplate",
-          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 641,
-              "column": 6
-            },
-            "end": {
-              "line": 652,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "is",
-              "type": "string",
-              "description": "Tag name (or type extension name) for this element"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        }
-      ],
-      "demos": [],
-      "metadata": {},
-      "sourceRange": {
-        "start": {
-          "line": 64,
-          "column": 8
-        },
-        "end": {
-          "line": 251,
-          "column": 9
-        }
-      },
-      "privacy": "public",
-      "superclass": "HTMLElement",
-      "name": "AnimadListHeader",
-      "attributes": [
-        {
-          "name": "search",
-          "description": "Query for which the user was searching",
-          "sourceRange": {
-            "start": {
-              "line": 72,
-              "column": 11
-            },
-            "end": {
-              "line": 76,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "selected-filters",
-          "description": "selectedFilters enthält die Information über alle ausgewählten Filter.",
-          "sourceRange": {
-            "start": {
-              "line": 80,
-              "column": 14
-            },
-            "end": {
-              "line": 85,
-              "column": 15
-            }
-          },
-          "metadata": {},
-          "type": "Array"
-        },
-        {
-          "name": "all-filters",
-          "description": "All filters from which the user can choose",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 11
-            },
-            "end": {
-              "line": 89,
-              "column": 29
-            }
-          },
-          "metadata": {},
-          "type": "Object"
-        },
-        {
-          "name": "hide-header",
-          "description": "Wether to hide the whole list header. Set attribute \"hide-header\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 93,
-              "column": 18
-            },
-            "end": {
-              "line": 93,
-              "column": 37
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "hide-filter-button",
-          "description": "Whether to hide the Filter button. Set attribute \"hide-filter-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 97,
-              "column": 11
-            },
-            "end": {
-              "line": 100,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "hide-delete-button",
-          "description": "Whether to hide the Delete button. Set attribute \"hide-delete-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 104,
-              "column": 11
-            },
-            "end": {
-              "line": 107,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "hide-new-button",
-          "description": "Whether to hide the New button. Set attribute \"hide-new-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 111,
-              "column": 11
-            },
-            "end": {
-              "line": 114,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "disable-filter-button",
-          "description": "Whether to disable the Filter button. Set attribute \"disable-filter-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 118,
-              "column": 11
-            },
-            "end": {
-              "line": 121,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "disable-delete-button",
-          "description": "Whether to disable the Delete button. Set attribute \"disable-delete-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 125,
-              "column": 11
-            },
-            "end": {
-              "line": 128,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "disable-new-button",
-          "description": "Whether to disable the New button. Set attribute \"disable-new-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 132,
-              "column": 11
-            },
-            "end": {
-              "line": 135,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "icon",
-          "description": "Icon shown in the search background",
-          "sourceRange": {
-            "start": {
-              "line": 139,
-              "column": 11
-            },
-            "end": {
-              "line": 142,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "placeholder-search",
-          "description": "Text shown in the search box if the user didn't enter any query",
-          "sourceRange": {
-            "start": {
-              "line": 146,
-              "column": 11
-            },
-            "end": {
-              "line": 149,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "placeholder-delete",
-          "description": "Text for Delete button if the user didn't enter any query",
-          "sourceRange": {
-            "start": {
-              "line": 153,
-              "column": 11
-            },
-            "end": {
-              "line": 156,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "placeholder-new",
-          "description": "Text for New button if the user didn't enter any query",
-          "sourceRange": {
-            "start": {
-              "line": 160,
-              "column": 11
-            },
-            "end": {
-              "line": 163,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "show-results",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "sourceRange": {
-            "start": {
-              "line": 174,
-              "column": 14
-            },
-            "end": {
-              "line": 177,
-              "column": 15
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "results-text",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "sourceRange": {
-            "start": {
-              "line": 181,
-              "column": 14
-            },
-            "end": {
-              "line": 184,
-              "column": 15
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        }
-      ],
-      "events": [
-        {
-          "type": "CustomEvent",
-          "name": "search-changed",
-          "description": "Fired when the `search` property changes.",
-          "metadata": {}
-        }
-      ],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
-      "slots": [],
-      "tagname": "animad-list-header"
-    },
-    {
       "description": "GENERATOR pattern: [DOMAINNAME]-[ENTITYNAME]-list\n\n`animad-animals-list` ist eine Liste zur Anzeige von Tieren, die über die angegebene [url](#/elements/animad-animals-list#property-url)\ngesucht werden.\n\nZur Suche können Suchbegriffe eingegeben werden, um die Anzahl der gefundenen Datensätze zu begrenzen. Diese Suchbegriffe können\nauch als Standard für die Liste festgelegt werden.\n\nDie gefundenen Datensätze können sortiert, selektiert und gelöscht werden.\n\nDie Navigation auf die Forms [`<animad-animal-create-form>`](#/elements/animad-animal-create-form)\nund [`<animad-animal-update-form>`](#/elements/animad-animal-update-form)\nzur Neuanlage bzw. zum Editieren eines Datensatzes ist möglich.\n\n#### Beispiel:\n\n    <animad-animals-list name=\"\"\n      url=\"http://localhost:39146/animals\"\n      default-search='name:Benjamin'\n      route=\"{{subroute}}\"\n      edit-path=\"/animal-view/edit\"\n      create-path=\"/animal-view/create\">\n    </animad-animals-list>",
       "summary": "",
       "path": "src/animad-animal/animad-animals-list.html",
@@ -15038,11 +10839,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
               "column": 15
             }
           },
@@ -15053,18 +10854,18 @@
           "inheritedFrom": "AnimadListBehavior"
         },
         {
-          "name": "_filteredData",
+          "name": "filteredData",
           "type": "Array",
-          "description": "_filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus _filteredData an.",
-          "privacy": "protected",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "privacy": "public",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 26,
+              "line": 36,
               "column": 14
             },
             "end": {
-              "line": 31,
+              "line": 41,
               "column": 15
             }
           },
@@ -15081,11 +10882,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 36,
+              "line": 46,
               "column": 14
             },
             "end": {
-              "line": 41,
+              "line": 51,
               "column": 15
             }
           },
@@ -15103,11 +10904,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -15124,11 +10925,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 81,
+              "line": 91,
               "column": 14
             },
             "end": {
-              "line": 83,
+              "line": 93,
               "column": 15
             }
           },
@@ -15145,11 +10946,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 87,
+              "line": 97,
               "column": 14
             },
             "end": {
-              "line": 92,
+              "line": 102,
               "column": 15
             }
           },
@@ -15167,11 +10968,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 96,
+              "line": 106,
               "column": 14
             },
             "end": {
-              "line": 98,
+              "line": 108,
               "column": 15
             }
           },
@@ -15188,11 +10989,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -15210,11 +11011,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 109,
+              "line": 119,
               "column": 14
             },
             "end": {
-              "line": 112,
+              "line": 122,
               "column": 15
             }
           },
@@ -15232,11 +11033,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 116,
+              "line": 126,
               "column": 14
             },
             "end": {
-              "line": 119,
+              "line": 129,
               "column": 15
             }
           },
@@ -15254,11 +11055,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 125,
+              "line": 135,
               "column": 14
             },
             "end": {
-              "line": 128,
+              "line": 138,
               "column": 15
             }
           },
@@ -15276,11 +11077,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 134,
+              "line": 144,
               "column": 14
             },
             "end": {
-              "line": 137,
+              "line": 147,
               "column": 15
             }
           },
@@ -15298,11 +11099,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 141,
+              "line": 151,
               "column": 14
             },
             "end": {
-              "line": 146,
+              "line": 156,
               "column": 15
             }
           },
@@ -15320,11 +11121,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 148,
+              "line": 158,
               "column": 14
             },
             "end": {
-              "line": 151,
+              "line": 161,
               "column": 15
             }
           },
@@ -15343,11 +11144,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -15365,11 +11166,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -15387,11 +11188,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -15409,11 +11210,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -15431,11 +11232,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -15453,11 +11254,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -15475,11 +11276,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -15497,11 +11298,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -15519,11 +11320,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -15541,11 +11342,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -15563,11 +11364,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -15584,11 +11385,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -15605,11 +11406,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -15627,11 +11428,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -15649,11 +11450,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -15671,11 +11472,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 282,
+              "line": 292,
               "column": 14
             },
             "end": {
-              "line": 284,
+              "line": 294,
               "column": 15
             }
           },
@@ -15692,11 +11493,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 288,
+              "line": 298,
               "column": 14
             },
             "end": {
-              "line": 291,
+              "line": 301,
               "column": 15
             }
           },
@@ -15714,11 +11515,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 296,
+              "line": 306,
               "column": 14
             },
             "end": {
-              "line": 299,
+              "line": 309,
               "column": 15
             }
           },
@@ -15736,11 +11537,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 303,
+              "line": 313,
               "column": 14
             },
             "end": {
-              "line": 306,
+              "line": 316,
               "column": 15
             }
           },
@@ -15758,11 +11559,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 310,
+              "line": 320,
               "column": 14
             },
             "end": {
-              "line": 312,
+              "line": 322,
               "column": 15
             }
           },
@@ -15883,11 +11684,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 326,
+              "line": 336,
               "column": 8
             },
             "end": {
-              "line": 329,
+              "line": 339,
               "column": 9
             }
           },
@@ -15902,11 +11703,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 336,
+              "line": 346,
               "column": 8
             },
             "end": {
-              "line": 366,
+              "line": 376,
               "column": 9
             }
           },
@@ -15919,17 +11720,36 @@
           "inheritedFrom": "AnimadListBehavior"
         },
         {
+          "name": "_onFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../behaviors/animad-list-behavior.html",
+            "start": {
+              "line": 378,
+              "column": 8
+            },
+            "end": {
+              "line": 384,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "AnimadListBehavior"
+        },
+        {
           "name": "_deselectItems",
           "description": "Deselektiert alle Datensätze",
           "privacy": "protected",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 371,
+              "line": 389,
               "column": 8
             },
             "end": {
-              "line": 379,
+              "line": 397,
               "column": 9
             }
           },
@@ -15948,11 +11768,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 385,
+              "line": 403,
               "column": 8
             },
             "end": {
-              "line": 387,
+              "line": 405,
               "column": 9
             }
           },
@@ -15971,11 +11791,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 393,
+              "line": 411,
               "column": 8
             },
             "end": {
-              "line": 395,
+              "line": 413,
               "column": 9
             }
           },
@@ -15994,11 +11814,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 402,
+              "line": 420,
               "column": 8
             },
             "end": {
-              "line": 404,
+              "line": 422,
               "column": 9
             }
           },
@@ -16017,11 +11837,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 410,
+              "line": 428,
               "column": 8
             },
             "end": {
-              "line": 433,
+              "line": 451,
               "column": 9
             }
           },
@@ -16043,11 +11863,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 440,
+              "line": 458,
               "column": 8
             },
             "end": {
-              "line": 452,
+              "line": 470,
               "column": 9
             }
           },
@@ -16062,11 +11882,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 457,
+              "line": 475,
               "column": 8
             },
             "end": {
-              "line": 462,
+              "line": 480,
               "column": 9
             }
           },
@@ -16085,11 +11905,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 469,
+              "line": 487,
               "column": 8
             },
             "end": {
-              "line": 492,
+              "line": 511,
               "column": 9
             }
           },
@@ -16108,11 +11928,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 498,
+              "line": 517,
               "column": 8
             },
             "end": {
-              "line": 517,
+              "line": 536,
               "column": 9
             }
           },
@@ -16131,11 +11951,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 523,
+              "line": 542,
               "column": 8
             },
             "end": {
-              "line": 539,
+              "line": 558,
               "column": 9
             }
           },
@@ -16171,11 +11991,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 563,
+              "line": 582,
               "column": 8
             },
             "end": {
-              "line": 572,
+              "line": 591,
               "column": 9
             }
           },
@@ -16190,11 +12010,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 577,
+              "line": 596,
               "column": 8
             },
             "end": {
-              "line": 580,
+              "line": 599,
               "column": 9
             }
           },
@@ -16209,11 +12029,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 586,
+              "line": 605,
               "column": 8
             },
             "end": {
-              "line": 615,
+              "line": 635,
               "column": 9
             }
           },
@@ -16230,16 +12050,16 @@
         },
         {
           "name": "_transferCellnameToFieldname",
-          "description": "Wandelt den tabellennamen in den korrespondierenden Backend-Feldnamen um",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 620,
+              "line": 637,
               "column": 8
             },
             "end": {
-              "line": 642,
+              "line": 657,
               "column": 9
             }
           },
@@ -16261,11 +12081,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 648,
+              "line": 663,
               "column": 8
             },
             "end": {
-              "line": 657,
+              "line": 673,
               "column": 9
             }
           },
@@ -16284,11 +12104,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 662,
+              "line": 678,
               "column": 8
             },
             "end": {
-              "line": 688,
+              "line": 705,
               "column": 9
             }
           },
@@ -16307,11 +12127,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 702,
+              "line": 719,
               "column": 8
             },
             "end": {
-              "line": 706,
+              "line": 723,
               "column": 9
             }
           },
@@ -16333,11 +12153,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 711,
+              "line": 728,
               "column": 8
             },
             "end": {
-              "line": 715,
+              "line": 732,
               "column": 9
             }
           },
@@ -16359,11 +12179,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 720,
+              "line": 737,
               "column": 8
             },
             "end": {
-              "line": 724,
+              "line": 741,
               "column": 9
             }
           },
@@ -16597,11 +12417,29 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
+              "column": 15
+            }
+          },
+          "metadata": {},
+          "type": "Array",
+          "inheritedFrom": "AnimadListBehavior"
+        },
+        {
+          "name": "filtered-data",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "sourceRange": {
+            "file": "../behaviors/animad-list-behavior.html",
+            "start": {
+              "line": 36,
+              "column": 14
+            },
+            "end": {
+              "line": 41,
               "column": 15
             }
           },
@@ -16615,11 +12453,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -16633,11 +12471,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -16651,11 +12489,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -16669,11 +12507,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -16687,11 +12525,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -16705,11 +12543,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -16723,11 +12561,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -16741,11 +12579,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -16759,11 +12597,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -16777,11 +12615,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -16795,11 +12633,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -16813,11 +12651,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -16831,11 +12669,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -16849,11 +12687,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -16867,11 +12705,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -16885,11 +12723,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -16903,11 +12741,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -16952,7 +12790,15 @@
           "inheritedFrom": "AnimadI18nBehavior"
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "filter-data",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "metadata": {},
+          "inheritedFrom": "AnimadListBehavior"
+        }
+      ],
       "styling": {
         "cssVariables": [],
         "selectors": []
@@ -17568,11 +13414,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 103,
+              "line": 106,
               "column": 10
             },
             "end": {
-              "line": 106,
+              "line": 109,
               "column": 11
             }
           },
@@ -17588,11 +13434,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 115,
+              "line": 118,
               "column": 10
             },
             "end": {
-              "line": 118,
+              "line": 121,
               "column": 11
             }
           },
@@ -17600,6 +13446,25 @@
             "polymer": {}
           },
           "defaultValue": "\"animad-animals\""
+        },
+        {
+          "name": "backendUrl",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 122,
+              "column": 10
+            },
+            "end": {
+              "line": 124,
+              "column": 11
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
         }
       ],
       "methods": [],
@@ -17608,18 +13473,35 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 91,
+          "line": 94,
           "column": 4
         },
         "end": {
-          "line": 121,
+          "line": 127,
           "column": 5
         }
       },
       "privacy": "public",
       "superclass": "HTMLElement",
       "name": "AnimadAnimalsView",
-      "attributes": [],
+      "attributes": [
+        {
+          "name": "backend-url",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 122,
+              "column": 10
+            },
+            "end": {
+              "line": 124,
+              "column": 11
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
       "events": [],
       "styling": {
         "cssVariables": [],
@@ -17627,4378 +13509,6 @@
       },
       "slots": [],
       "tagname": "animad-animals-view"
-    },
-    {
-      "description": "",
-      "summary": "",
-      "path": "src/animad-enclosure/animad-list-header.html",
-      "properties": [
-        {
-          "name": "__serializing",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 125,
-              "column": 8
-            },
-            "end": {
-              "line": 125,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataCounter",
-          "type": "number",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1171,
-              "column": 8
-            },
-            "end": {
-              "line": 1171,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataEnabled",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 129,
-              "column": 8
-            },
-            "end": {
-              "line": 129,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataReady",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 131,
-              "column": 8
-            },
-            "end": {
-              "line": 131,
-              "column": 25
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataInvalid",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 133,
-              "column": 8
-            },
-            "end": {
-              "line": 133,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__data",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1153,
-              "column": 8
-            },
-            "end": {
-              "line": 1153,
-              "column": 20
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataPending",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1155,
-              "column": 8
-            },
-            "end": {
-              "line": 1155,
-              "column": 27
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataOld",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1157,
-              "column": 8
-            },
-            "end": {
-              "line": 1157,
-              "column": 23
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataProto",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 141,
-              "column": 8
-            },
-            "end": {
-              "line": 141,
-              "column": 25
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataHasAccessor",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 143,
-              "column": 8
-            },
-            "end": {
-              "line": 143,
-              "column": 31
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataInstanceProps",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 145,
-              "column": 8
-            },
-            "end": {
-              "line": 145,
-              "column": 33
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "__dataClientsReady",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1135,
-              "column": 8
-            },
-            "end": {
-              "line": 1135,
-              "column": 32
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataPendingClients",
-          "type": "Array",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1137,
-              "column": 8
-            },
-            "end": {
-              "line": 1137,
-              "column": 34
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataToNotify",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1139,
-              "column": 8
-            },
-            "end": {
-              "line": 1139,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataLinkedPaths",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1141,
-              "column": 8
-            },
-            "end": {
-              "line": 1141,
-              "column": 31
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataHasPaths",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1143,
-              "column": 8
-            },
-            "end": {
-              "line": 1143,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataCompoundStorage",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1145,
-              "column": 8
-            },
-            "end": {
-              "line": 1145,
-              "column": 35
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataHost",
-          "type": "Polymer_PropertyEffects",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1147,
-              "column": 8
-            },
-            "end": {
-              "line": 1147,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataTemp",
-          "type": "!Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1149,
-              "column": 8
-            },
-            "end": {
-              "line": 1149,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__dataClientsInitialized",
-          "type": "boolean",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1151,
-              "column": 8
-            },
-            "end": {
-              "line": 1151,
-              "column": 38
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__computeEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1159,
-              "column": 8
-            },
-            "end": {
-              "line": 1159,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__reflectEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1161,
-              "column": 8
-            },
-            "end": {
-              "line": 1161,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__notifyEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1163,
-              "column": 8
-            },
-            "end": {
-              "line": 1163,
-              "column": 29
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__propagateEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1165,
-              "column": 8
-            },
-            "end": {
-              "line": 1165,
-              "column": 32
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__observeEffects",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1167,
-              "column": 8
-            },
-            "end": {
-              "line": 1167,
-              "column": 30
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__readOnly",
-          "type": "Object",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1169,
-              "column": 8
-            },
-            "end": {
-              "line": 1169,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__templateInfo",
-          "type": "!TemplateInfo",
-          "description": "",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1173,
-              "column": 8
-            },
-            "end": {
-              "line": 1173,
-              "column": 28
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_template",
-          "type": "HTMLTemplateElement",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 560,
-              "column": 8
-            },
-            "end": {
-              "line": 560,
-              "column": 23
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_importPath",
-          "type": "string",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 562,
-              "column": 8
-            },
-            "end": {
-              "line": 562,
-              "column": 25
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "rootPath",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 564,
-              "column": 8
-            },
-            "end": {
-              "line": 564,
-              "column": 22
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "importPath",
-          "type": "string",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 566,
-              "column": 8
-            },
-            "end": {
-              "line": 566,
-              "column": 24
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "root",
-          "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 568,
-              "column": 8
-            },
-            "end": {
-              "line": 568,
-              "column": 18
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "$",
-          "type": "!Object.<string, !Element>",
-          "description": "",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 570,
-              "column": 8
-            },
-            "end": {
-              "line": 570,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "readOnly": false
-            }
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "search",
-          "type": "string",
-          "description": "Query for which the user was searching",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 72,
-              "column": 11
-            },
-            "end": {
-              "line": 76,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {
-              "notify": true,
-              "observer": "\"_onChangeRequest\""
-            }
-          }
-        },
-        {
-          "name": "selectedFilters",
-          "type": "Array",
-          "description": "selectedFilters enthält die Information über alle ausgewählten Filter.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 80,
-              "column": 14
-            },
-            "end": {
-              "line": 85,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "[]"
-        },
-        {
-          "name": "allFilters",
-          "type": "Object",
-          "description": "All filters from which the user can choose",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 11
-            },
-            "end": {
-              "line": 89,
-              "column": 29
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          }
-        },
-        {
-          "name": "hideHeader",
-          "type": "boolean",
-          "description": "Wether to hide the whole list header. Set attribute \"hide-header\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 93,
-              "column": 18
-            },
-            "end": {
-              "line": 93,
-              "column": 37
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          }
-        },
-        {
-          "name": "hideFilterButton",
-          "type": "boolean",
-          "description": "Whether to hide the Filter button. Set attribute \"hide-filter-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 97,
-              "column": 11
-            },
-            "end": {
-              "line": 100,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "hideDeleteButton",
-          "type": "boolean",
-          "description": "Whether to hide the Delete button. Set attribute \"hide-delete-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 104,
-              "column": 11
-            },
-            "end": {
-              "line": 107,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "hideNewButton",
-          "type": "boolean",
-          "description": "Whether to hide the New button. Set attribute \"hide-new-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 111,
-              "column": 11
-            },
-            "end": {
-              "line": 114,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "disableFilterButton",
-          "type": "boolean",
-          "description": "Whether to disable the Filter button. Set attribute \"disable-filter-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 118,
-              "column": 11
-            },
-            "end": {
-              "line": 121,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "disableDeleteButton",
-          "type": "boolean",
-          "description": "Whether to disable the Delete button. Set attribute \"disable-delete-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 125,
-              "column": 11
-            },
-            "end": {
-              "line": 128,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "disableNewButton",
-          "type": "boolean",
-          "description": "Whether to disable the New button. Set attribute \"disable-new-button\" to do so.",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 132,
-              "column": 11
-            },
-            "end": {
-              "line": 135,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "icon",
-          "type": "string",
-          "description": "Icon shown in the search background",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 139,
-              "column": 11
-            },
-            "end": {
-              "line": 142,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"search\""
-        },
-        {
-          "name": "placeholderSearch",
-          "type": "string",
-          "description": "Text shown in the search box if the user didn't enter any query",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 146,
-              "column": 11
-            },
-            "end": {
-              "line": 149,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"Search\""
-        },
-        {
-          "name": "placeholderDelete",
-          "type": "string",
-          "description": "Text for Delete button if the user didn't enter any query",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 153,
-              "column": 11
-            },
-            "end": {
-              "line": 156,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"Delete\""
-        },
-        {
-          "name": "placeholderNew",
-          "type": "string",
-          "description": "Text for New button if the user didn't enter any query",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 160,
-              "column": 11
-            },
-            "end": {
-              "line": 163,
-              "column": 12
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"New\""
-        },
-        {
-          "name": "_isFilterSelectionOpen",
-          "type": "boolean",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 167,
-              "column": 14
-            },
-            "end": {
-              "line": 170,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "false"
-        },
-        {
-          "name": "showResults",
-          "type": "boolean",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 174,
-              "column": 14
-            },
-            "end": {
-              "line": 177,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "true"
-        },
-        {
-          "name": "resultsText",
-          "type": "string",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "privacy": "public",
-          "sourceRange": {
-            "start": {
-              "line": 181,
-              "column": 14
-            },
-            "end": {
-              "line": 184,
-              "column": 15
-            }
-          },
-          "metadata": {
-            "polymer": {}
-          },
-          "defaultValue": "\"\""
-        }
-      ],
-      "methods": [
-        {
-          "name": "_stampTemplate",
-          "description": "Stamps the provided template and performs instance-time setup for\nPolymer template features, including data bindings, declarative event\nlisteners, and the `this.$` map of `id`'s to nodes.  A document fragment\nis returned containing the stamped DOM, ready for insertion into the\nDOM.\n\nThis method may be called more than once; however note that due to\n`shadycss` polyfill limitations, only styles from templates prepared\nusing `ShadyCSS.prepareTemplate` will be correctly polyfilled (scoped\nto the shadow root and support CSS custom properties), and note that\n`ShadyCSS.prepareTemplate` may only be called once per element. As such,\nany styles required by in runtime-stamped templates must be included\nin the main element template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2366,
-              "column": 6
-            },
-            "end": {
-              "line": 2391,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template to stamp"
-            }
-          ],
-          "return": {
-            "type": "!StampedTemplate",
-            "desc": "Cloned template content"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_addMethodEventListenerToNode",
-          "description": "Adds an event listener by method name for the event provided.\n\nThis method generates a handler function that looks up the method\nname at handling time.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 452,
-              "column": 6
-            },
-            "end": {
-              "line": 457,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to add listener on"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "methodName",
-              "type": "string",
-              "description": "Name of method"
-            },
-            {
-              "name": "context",
-              "type": "*=",
-              "description": "Context the method will be called on (defaults\n  to `node`)"
-            }
-          ],
-          "return": {
-            "type": "Function",
-            "desc": "Generated handler function"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_addEventListenerToNode",
-          "description": "Override point for adding custom or simulated event handling.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 467,
-              "column": 6
-            },
-            "end": {
-              "line": 469,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to add event listener to"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "handler",
-              "type": "Function",
-              "description": "Listener function to add"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_removeEventListenerFromNode",
-          "description": "Override point for adding custom or simulated event handling.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 479,
-              "column": 6
-            },
-            "end": {
-              "line": 481,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to remove event listener from"
-            },
-            {
-              "name": "eventName",
-              "type": "string",
-              "description": "Name of event"
-            },
-            {
-              "name": "handler",
-              "type": "Function",
-              "description": "Listener function to remove"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "attributeChangedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`attributeChangedCallback`.\n\nBy default, attributes declared in `properties` metadata are\ndeserialized using their `type` information to properties of the\nsame name.  \"Dash-cased\" attributes are deserialized to \"camelCase\"\nproperties.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 754,
-              "column": 6
-            },
-            "end": {
-              "line": 762,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Name of attribute."
-            },
-            {
-              "name": "old",
-              "type": "?string",
-              "description": "Old value of attribute."
-            },
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "Current value of attribute."
-            }
-          ],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_initializeProperties",
-          "description": "Overrides the default `Polymer.PropertyAccessors` to ensure class\nmetaprogramming related to property accessors and effects has\ncompleted (calls `finalize`).\n\nIt also initializes any property defaults provided via `value` in\n`properties` metadata.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 584,
-              "column": 6
-            },
-            "end": {
-              "line": 618,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_initializeProtoProperties",
-          "description": "Overrides `Polymer.PropertyAccessors` implementation to provide a\nmore efficient implementation of initializing properties from\nthe prototype on the instance.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1203,
-              "column": 6
-            },
-            "end": {
-              "line": 1207,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Properties to initialize on the prototype"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_initializeInstanceProperties",
-          "description": "Overrides `Polymer.PropertyAccessors` implementation to avoid setting\n`_setProperty`'s `shouldNotify: true`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1216,
-              "column": 6
-            },
-            "end": {
-              "line": 1225,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Properties to initialize on the instance"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_ensureAttribute",
-          "description": "Ensures the element has the given attribute. If it does not,\nassigns the given value to the attribute.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 242,
-              "column": 6
-            },
-            "end": {
-              "line": 246,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Name of attribute to ensure is set."
-            },
-            {
-              "name": "value",
-              "type": "string",
-              "description": "of the attribute."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_attributeToProperty",
-          "description": "Deserializes an attribute to its associated property.\n\nThis method calls the `_deserializeValue` method to convert the string to\na typed value.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 259,
-              "column": 6
-            },
-            "end": {
-              "line": 265,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Name of attribute to deserialize."
-            },
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "of the attribute."
-            },
-            {
-              "name": "type",
-              "type": "*=",
-              "description": "type to deserialize to."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_propertyToAttribute",
-          "description": "Serializes a property to its associated attribute.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 275,
-              "column": 6
-            },
-            "end": {
-              "line": 281,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name to reflect."
-            },
-            {
-              "name": "attribute",
-              "type": "string=",
-              "description": "Attribute name to reflect."
-            },
-            {
-              "name": "value",
-              "type": "*=",
-              "description": "Property value to refect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_valueToNodeAttribute",
-          "description": "Sets a typed value to an HTML attribute on a node.\n\nThis method calls the `_serializeValue` method to convert the typed\nvalue to a string.  If the `_serializeValue` method returns `undefined`,\nthe attribute will be removed (this is the default for boolean\ntype `false`).",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 296,
-              "column": 6
-            },
-            "end": {
-              "line": 303,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Element to set attribute to."
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to serialize."
-            },
-            {
-              "name": "attribute",
-              "type": "string",
-              "description": "Attribute name to serialize to."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_serializeValue",
-          "description": "Converts a typed JavaScript value to a string.\n\nThis method is called by Polymer when setting JS property values to\nHTML attributes.  Users may override this method on Polymer element\nprototypes to provide serialization for custom types.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 315,
-              "column": 6
-            },
-            "end": {
-              "line": 335,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Property value to serialize."
-            }
-          ],
-          "return": {
-            "type": "(string|undefined)",
-            "desc": "String serialized from the provided property value."
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_deserializeValue",
-          "description": "Converts a string to a typed JavaScript value.\n\nThis method is called by Polymer when reading HTML attribute values to\nJS properties.  Users may override this method on Polymer element\nprototypes to provide deserialization for custom `type`s.  Note,\nthe `type` argument is the value of the `type` field provided in the\n`properties` configuration object for a given property, and is\nby convention the constructor for the type to deserialize.\n\nNote: The return value of `undefined` is used as a sentinel value to\nindicate the attribute should be removed.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 354,
-              "column": 6
-            },
-            "end": {
-              "line": 397,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "value",
-              "type": "?string",
-              "description": "Attribute value to deserialize."
-            },
-            {
-              "name": "type",
-              "type": "*=",
-              "description": "Type to deserialize the string to."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Typed value deserialized from the provided string."
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_createPropertyAccessor",
-          "description": "Creates a setter/getter pair for the named property with its own\nlocal storage.  The getter returns the value in the local storage,\nand the setter calls `_setProperty`, which updates the local storage\nfor the property and enqueues a `_propertiesChanged` callback.\n\nThis method may be called on a prototype or an instance.  Calling\nthis method may overwrite a property value that already exists on\nthe prototype/instance by creating the accessor.  When calling on\na prototype, any overwritten values are saved in `__dataProto`,\nand it is up to the subclasser to decide how/when to set those\nproperties back into the accessor.  When calling on an instance,\nthe overwritten value is set via `_setPendingProperty`, and the\nuser should call `_invalidateProperties` or `_flushProperties`\nfor the values to take effect.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 422,
-              "column": 6
-            },
-            "end": {
-              "line": 442,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "readOnly",
-              "type": "boolean=",
-              "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_hasAccessor",
-          "description": "Returns true if this library created an accessor for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 450,
-              "column": 6
-            },
-            "end": {
-              "line": 452,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if an accessor was created"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_setProperty",
-          "description": "Overrides base implementation to ensure all accessors set `shouldNotify`\nto true, for per-property notification tracking.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1495,
-              "column": 6
-            },
-            "end": {
-              "line": 1499,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property"
-            },
-            {
-              "name": "value"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setPendingProperty",
-          "description": "Overrides the `PropertyAccessors` implementation to introduce special\ndirty check logic depending on the property & value being set:\n\n1. Any value set to a path (e.g. 'obj.prop': 42 or 'obj.prop': {...})\n   Stored in `__dataTemp`, dirty checked against `__dataTemp`\n2. Object set to simple property (e.g. 'prop': {...})\n   Stored in `__dataTemp` and `__data`, dirty checked against\n   `__dataTemp` by default implementation of `_shouldPropertyChange`\n3. Primitive value set to simple property (e.g. 'prop': 42)\n   Stored in `__data`, dirty checked against `__data`\n\nThe dirty-check is important to prevent cycles due to two-way\nnotification, but paths and objects are only dirty checked against any\nprevious value set during this turn via a \"temporary cache\" that is\ncleared when the last `_propertiesChanged` exits. This is so:\na. any cached array paths (e.g. 'array.3.prop') may be invalidated\n   due to array mutations like shift/unshift/splice; this is fine\n   since path changes are dirty-checked at user entry points like `set`\nb. dirty-checking for objects only lasts one turn to allow the user\n   to mutate the object in-place and re-set it with the same identity\n   and have all sub-properties re-propagated in a subsequent turn.\n\nThe temp cache is not necessarily sufficient to prevent invalid array\npaths, since a splice can happen during the same turn (with pathological\nuser code); we could introduce a \"fixup\" for temporarily cached array\npaths if needed: https://github.com/Polymer/polymer/issues/4227",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1458,
-              "column": 6
-            },
-            "end": {
-              "line": 1487,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of the property"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set"
-            },
-            {
-              "name": "shouldNotify",
-              "type": "boolean=",
-              "description": "True if property should fire notification\n  event (applies only for `notify: true` properties)"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Returns true if the property changed"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_isPropertyPending",
-          "description": "Returns true if the specified property has a pending change.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 505,
-              "column": 6
-            },
-            "end": {
-              "line": 507,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if property has a pending change"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_invalidateProperties",
-          "description": "Overrides `PropertyAccessor`'s default async queuing of\n`_propertiesChanged`: if `__dataReady` is false (has not yet been\nmanually flushed), the function no-ops; otherwise flushes\n`_propertiesChanged` synchronously.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1509,
-              "column": 6
-            },
-            "end": {
-              "line": 1513,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_enableProperties",
-          "description": "Call to enable property accessor processing. Before this method is\ncalled accessor values will be set but side effects are\nqueued. When called, any pending side effects occur immediately.\nFor elements, generally `connectedCallback` is a normal spot to do so.\nIt is safe to call this method multiple times as it only turns on\nproperty accessors once.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 538,
-              "column": 6
-            },
-            "end": {
-              "line": 547,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_flushProperties",
-          "description": "Calls the `_propertiesChanged` callback with the current set of\npending changes (and old values recorded when pending changes were\nset), and resets the pending set of changes. Generally, this method\nshould not be called in user code.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 558,
-              "column": 6
-            },
-            "end": {
-              "line": 566,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "ready",
-          "description": "Stamps the element template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 682,
-              "column": 6
-            },
-            "end": {
-              "line": 688,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_propertiesChanged",
-          "description": "Implements `PropertyAccessors`'s properties changed callback.\n\nRuns each class of effects for the batch of changed properties in\na specific order (compute, propagate, reflect, observe, notify).",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1652,
-              "column": 6
-            },
-            "end": {
-              "line": 1685,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "currentProps"
-            },
-            {
-              "name": "changedProps"
-            },
-            {
-              "name": "oldProps"
-            }
-          ],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_shouldPropertyChange",
-          "description": "Method called to determine whether a property value should be\nconsidered as a change and cause the `_propertiesChanged` callback\nto be enqueued.\n\nThe default implementation returns `true` for primitive types if a\nstrict equality check fails, and returns `true` for all Object/Arrays.\nThe method always returns false for `NaN`.\n\nOverride this method to e.g. provide stricter checking for\nObjects/Arrays when using immutable patterns.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 621,
-              "column": 6
-            },
-            "end": {
-              "line": 624,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "New property value"
-            },
-            {
-              "name": "old",
-              "type": "*",
-              "description": "Previous property value"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Whether the property should be considered a change\n  and enqueue a `_propertiesChanged` callback"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "_addPropertyEffect",
-          "description": "Equivalent to static `addPropertyEffect` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1240,
-              "column": 6
-            },
-            "end": {
-              "line": 1248,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_removePropertyEffect",
-          "description": "Removes the given property effect.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1258,
-              "column": 6
-            },
-            "end": {
-              "line": 1264,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property the effect was associated with"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object to remove"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasPropertyEffect",
-          "description": "Returns whether the current prototype/instance has a property effect\nof a certain type.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1275,
-              "column": 6
-            },
-            "end": {
-              "line": 1278,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "type",
-              "type": "string=",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasReadOnlyEffect",
-          "description": "Returns whether the current prototype/instance has a \"read only\"\naccessor for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1288,
-              "column": 6
-            },
-            "end": {
-              "line": 1290,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasNotifyEffect",
-          "description": "Returns whether the current prototype/instance has a \"notify\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1300,
-              "column": 6
-            },
-            "end": {
-              "line": 1302,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasReflectEffect",
-          "description": "Returns whether the current prototype/instance has a \"reflect to attribute\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1312,
-              "column": 6
-            },
-            "end": {
-              "line": 1314,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_hasComputedEffect",
-          "description": "Returns whether the current prototype/instance has a \"computed\"\nproperty effect for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1324,
-              "column": 6
-            },
-            "end": {
-              "line": 1326,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "True if the prototype/instance has an effect of this type"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setPendingPropertyOrPath",
-          "description": "Sets a pending property or path.  If the root property of the path in\nquestion had no accessor, the path is set, otherwise it is enqueued\nvia `_setPendingProperty`.\n\nThis function isolates relatively expensive functionality necessary\nfor the public API (`set`, `setProperties`, `notifyPath`, and property\nchange listeners via {{...}} bindings), such that it is only done\nwhen paths enter the system, and not at every propagation step.  It\nalso sets a `__dataHasPaths` flag on the instance which is used to\nfast-path slower path-matching code in the property effects host paths.\n\n`path` can be a path string or array of path parts as accepted by the\npublic API.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1358,
-              "column": 6
-            },
-            "end": {
-              "line": 1390,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(number|string)>)",
-              "description": "Path to set"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set"
-            },
-            {
-              "name": "shouldNotify",
-              "type": "boolean=",
-              "description": "Set to true if this change should\n cause a property notification event dispatch"
-            },
-            {
-              "name": "isPathNotification",
-              "type": "boolean=",
-              "description": "If the path being set is a path\n  notification of an already changed value, as opposed to a request\n  to set and notify the change.  In the latter `false` case, a dirty\n  check is performed and then the value is set to the path before\n  enqueuing the pending property change."
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "Returns true if the property/path was enqueued in\n  the pending changes bag."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_setUnmanagedPropertyToNode",
-          "description": "Applies a value to a non-Polymer element/node's property.\n\nThe implementation makes a best-effort at binding interop:\nSome native element properties have side-effects when\nre-setting the same value (e.g. setting `<input>.value` resets the\ncursor position), so we do a dirty-check before setting the value.\nHowever, for better interop with non-Polymer custom elements that\naccept objects, we explicitly re-set object changes coming from the\nPolymer world (which may include deep object changes without the\ntop reference changing), erring on the side of providing more\ninformation.\n\nUsers may override this method to provide alternate approaches.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1413,
-              "column": 6
-            },
-            "end": {
-              "line": 1421,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "The node to set a property on"
-            },
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "The property to set"
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "The value to set"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_enqueueClient",
-          "description": "Enqueues the given client on a list of pending clients, whose\npending property changes can later be flushed via a call to\n`_flushClients`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1524,
-              "column": 6
-            },
-            "end": {
-              "line": 1529,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "client",
-              "type": "Object",
-              "description": "PropertyEffects client to enqueue"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_flushClients",
-          "description": "Flushes any clients previously enqueued via `_enqueueClient`, causing\ntheir `_flushProperties` method to run.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1538,
-              "column": 6
-            },
-            "end": {
-              "line": 1549,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "__enableOrFlushClients",
-          "description": "(c) the stamped dom enables.",
-          "privacy": "private",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1563,
-              "column": 6
-            },
-            "end": {
-              "line": 1576,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_readyClients",
-          "description": "Implements `PropertyEffects`'s `_readyClients` call. Attaches\nelement dom by calling `_attachDom` with the dom stamped from the\nelement's template via `_stampTemplate`. Note that this allows\nclient dom to be attached to the element prior to any observers\nrunning.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 699,
-              "column": 6
-            },
-            "end": {
-              "line": 708,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "setProperties",
-          "description": "Sets a bag of property changes to this instance, and\nsynchronously processes all effects of the properties as a batch.\n\nProperty names must be simple properties, not paths.  Batched\npath propagation is not supported.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1605,
-              "column": 6
-            },
-            "end": {
-              "line": 1616,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of one or more key-value pairs whose key is\n  a property and value is the new value to set for that property."
-            },
-            {
-              "name": "setReadOnly",
-              "type": "boolean=",
-              "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_propagatePropertyChanges",
-          "description": "Called to propagate any property changes to stamped template nodes\nmanaged by this element.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1697,
-              "column": 6
-            },
-            "end": {
-              "line": 1707,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "changedProps",
-              "type": "Object",
-              "description": "Bag of changed properties"
-            },
-            {
-              "name": "oldProps",
-              "type": "Object",
-              "description": "Bag of previous values for changed properties"
-            },
-            {
-              "name": "hasPaths",
-              "type": "boolean",
-              "description": "True with `props` contains one or more paths"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "linkPaths",
-          "description": "Aliases one data path as another, such that path notifications from one\nare routed to the other.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1718,
-              "column": 6
-            },
-            "end": {
-              "line": 1723,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "to",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Target path to link."
-            },
-            {
-              "name": "from",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Source path to link."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "unlinkPaths",
-          "description": "Removes a data path alias previously established with `_linkPaths`.\n\nNote, the path to unlink should be the target (`to`) used when\nlinking the paths.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1735,
-              "column": 6
-            },
-            "end": {
-              "line": 1740,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Target path to unlink."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "notifySplices",
-          "description": "Notify that an array has changed.\n\nExample:\n\n    this.items = [ {name: 'Jim'}, {name: 'Todd'}, {name: 'Bill'} ];\n    ...\n    this.items.splice(1, 1, {name: 'Sam'});\n    this.items.push({name: 'Bob'});\n    this.notifySplices('items', [\n      { index: 1, removed: [{name: 'Todd'}], addedCount: 1, object: this.items, type: 'splice' },\n      { index: 3, removed: [], addedCount: 1, object: this.items, type: 'splice'}\n    ]);",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1772,
-              "column": 6
-            },
-            "end": {
-              "line": 1776,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Path that should be notified."
-            },
-            {
-              "name": "splices",
-              "type": "Array",
-              "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "get",
-          "description": "Convenience method for reading a value from a path.\n\nNote, if any part in the path is undefined, this method returns\n`undefined` (this method does not throw when dereferencing undefined\npaths).",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1797,
-              "column": 6
-            },
-            "end": {
-              "line": 1799,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
-            },
-            {
-              "name": "root",
-              "type": "Object=",
-              "description": "Root object from which the path is evaluated."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Value at the path, or `undefined` if any part of the path\n  is undefined."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "set",
-          "description": "Convenience method for setting a value to a path and notifying any\nelements bound to the same path.\n\nNote, if any part in the path except for the last is undefined,\nthis method does nothing (this method does not throw when\ndereferencing undefined paths).",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1822,
-              "column": 6
-            },
-            "end": {
-              "line": 1832,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
-            },
-            {
-              "name": "value",
-              "type": "*",
-              "description": "Value to set at the specified path."
-            },
-            {
-              "name": "root",
-              "type": "Object=",
-              "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "push",
-          "description": "Adds items onto the end of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1848,
-              "column": 6
-            },
-            "end": {
-              "line": 1857,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to push onto array"
-            }
-          ],
-          "return": {
-            "type": "number",
-            "desc": "New length of the array."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "pop",
-          "description": "Removes an item from the end of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1872,
-              "column": 6
-            },
-            "end": {
-              "line": 1881,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Item that was removed."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "splice",
-          "description": "Starting from the start index specified, removes 0 or more items\nfrom the array and inserts 0 or more new items in their place.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.splice`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1900,
-              "column": 6
-            },
-            "end": {
-              "line": 1917,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "start",
-              "type": "number",
-              "description": "Index from which to start removing/inserting."
-            },
-            {
-              "name": "deleteCount",
-              "type": "number",
-              "description": "Number of items to remove."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to insert into array."
-            }
-          ],
-          "return": {
-            "type": "Array",
-            "desc": "Array of removed items."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "shift",
-          "description": "Removes an item from the beginning of array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.pop`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1932,
-              "column": 6
-            },
-            "end": {
-              "line": 1941,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Item that was removed."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "unshift",
-          "description": "Adds items onto the beginning of the array at the path specified.\n\nThe arguments after `path` and return value match that of\n`Array.prototype.push`.\n\nThis method notifies other paths to the same array that a\nsplice occurred to the array.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1957,
-              "column": 6
-            },
-            "end": {
-              "line": 1965,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "(string|!Array.<(string|number)>)",
-              "description": "Path to array."
-            },
-            {
-              "name": "items",
-              "type": "...*",
-              "rest": true,
-              "description": "Items to insert info array"
-            }
-          ],
-          "return": {
-            "type": "number",
-            "desc": "New length of the array."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "notifyPath",
-          "description": "Notify that a path has changed.\n\nExample:\n\n    this.item.user.name = 'Bob';\n    this.notifyPath('item.user.name');",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 1980,
-              "column": 6
-            },
-            "end": {
-              "line": 1997,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Path that should be notified."
-            },
-            {
-              "name": "value",
-              "type": "*=",
-              "description": "Value at the path (optional)."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createReadOnlyProperty",
-          "description": "Equivalent to static `createReadOnlyProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2010,
-              "column": 6
-            },
-            "end": {
-              "line": 2017,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "protectedSetter",
-              "type": "boolean=",
-              "description": "Creates a custom protected setter\n  when `true`."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createPropertyObserver",
-          "description": "Equivalent to static `createPropertyObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2031,
-              "column": 6
-            },
-            "end": {
-              "line": 2041,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "method",
-              "type": "(string|function (*, *))",
-              "description": "Function or name of observer method to call"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "boolean=",
-              "description": "Whether the method name should be included as\n  a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createMethodObserver",
-          "description": "Equivalent to static `createMethodObserver` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2054,
-              "column": 6
-            },
-            "end": {
-              "line": 2060,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createNotifyingProperty",
-          "description": "Equivalent to static `createNotifyingProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2071,
-              "column": 6
-            },
-            "end": {
-              "line": 2079,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createReflectedProperty",
-          "description": "Equivalent to static `createReflectedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2090,
-              "column": 6
-            },
-            "end": {
-              "line": 2103,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_createComputedProperty",
-          "description": "Equivalent to static `createComputedProperty` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2117,
-              "column": 6
-            },
-            "end": {
-              "line": 2123,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of computed property to set"
-            },
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_bindTemplate",
-          "description": "Equivalent to static `bindTemplate` API but can be called on\nan instance to add effects at runtime.  See that method for\nfull API docs.\n\nThis method may be called on the prototype (for prototypical template\nbinding, to avoid creating accessors every instance) once per prototype,\nand will be called with `runtimeBinding: true` by `_stampTemplate` to\ncreate and link an instance of the template metadata associated with a\nparticular stamping.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2300,
-              "column": 6
-            },
-            "end": {
-              "line": 2323,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "HTMLTemplateElement",
-              "description": "Template containing binding\n  bindings"
-            },
-            {
-              "name": "instanceBinding",
-              "type": "boolean=",
-              "description": "When false (default), performs\n  \"prototypical\" binding of the template and overwrites any previously\n  bound template for the class. When true (as passed from\n  `_stampTemplate`), the template info is instanced and linked into\n  the list of bound templates."
-            }
-          ],
-          "return": {
-            "type": "!TemplateInfo",
-            "desc": "Template metadata object; for `runtimeBinding`,\n  this is an instance of the prototypical template info"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_removeBoundDom",
-          "description": "Removes and unbinds the nodes previously contained in the provided\nDocumentFragment returned from `_stampTemplate`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2402,
-              "column": 6
-            },
-            "end": {
-              "line": 2423,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "dom",
-              "type": "!StampedTemplate",
-              "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "connectedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`connectedCallback`.\n\nThe default implementation enables the property effects system and\nflushes any pending properties, and updates shimmed CSS properties\nwhen using the ShadyCSS scoping/custom properties polyfill.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 664,
-              "column": 6
-            },
-            "end": {
-              "line": 669,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "disconnectedCallback",
-          "description": "Provides a default implementation of the standard Custom Elements\n`disconnectedCallback`.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 675,
-              "column": 6
-            },
-            "end": {
-              "line": 675,
-              "column": 31
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_attachDom",
-          "description": "Attaches an element's stamped dom to itself. By default,\nthis method creates a `shadowRoot` and adds the dom to it.\nHowever, this method may be overridden to allow an element\nto put its dom in another location.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 722,
-              "column": 6
-            },
-            "end": {
-              "line": 738,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "dom",
-              "type": "StampedTemplate",
-              "description": "to attach to the element."
-            }
-          ],
-          "return": {
-            "type": "ShadowRoot",
-            "desc": "node to which the dom has been attached."
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "updateStyles",
-          "description": "When using the ShadyCSS scoping and custom property shim, causes all\nshimmed styles in this element (and its subtree) to be updated\nbased on current custom property values.\n\nThe optional parameter overrides inline custom property styles with an\nobject of properties where the keys are CSS properties, and the values\nare strings.\n\nExample: `this.updateStyles({'--color': 'blue'})`\n\nThese properties are retained unless a value of `null` is set.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 782,
-              "column": 6
-            },
-            "end": {
-              "line": 786,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "properties",
-              "type": "Object=",
-              "description": "Bag of custom property key/values to\n  apply to this element."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "resolveUrl",
-          "description": "Rewrites a given URL relative to a base URL. The base URL defaults to\nthe original location of the document containing the `dom-module` for\nthis element. This method will return the same URL before and after\nbundling.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 799,
-              "column": 6
-            },
-            "end": {
-              "line": 804,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "url",
-              "type": "string",
-              "description": "URL to resolve."
-            },
-            {
-              "name": "base",
-              "type": "string=",
-              "description": "Optional base URL to resolve against, defaults\nto the element's `importPath`"
-            }
-          ],
-          "return": {
-            "type": "string",
-            "desc": "Rewritten URL relative to base"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "attached",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 188,
-              "column": 12
-            },
-            "end": {
-              "line": 191,
-              "column": 13
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_onSearchRequest",
-          "description": "Private methods",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 194,
-              "column": 12
-            },
-            "end": {
-              "line": 196,
-              "column": 13
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_onChangeRequest",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 198,
-              "column": 7
-            },
-            "end": {
-              "line": 203,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "newValue"
-            },
-            {
-              "name": "oldValue"
-            }
-          ]
-        },
-        {
-          "name": "_onFilter",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 205,
-              "column": 9
-            },
-            "end": {
-              "line": 234,
-              "column": 10
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_onDelete",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 236,
-              "column": 9
-            },
-            "end": {
-              "line": 238,
-              "column": 10
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_onNew",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 239,
-              "column": 9
-            },
-            "end": {
-              "line": 241,
-              "column": 10
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "event"
-            }
-          ]
-        },
-        {
-          "name": "_toggleFilterSelectionOpen",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 242,
-              "column": 9
-            },
-            "end": {
-              "line": 244,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_hideFilterButton",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 245,
-              "column": 9
-            },
-            "end": {
-              "line": 247,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filters"
-            }
-          ]
-        },
-        {
-          "name": "_disableFilterButton",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 248,
-              "column": 7
-            },
-            "end": {
-              "line": 250,
-              "column": 8
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "filters"
-            }
-          ]
-        }
-      ],
-      "staticMethods": [
-        {
-          "name": "_parseTemplate",
-          "description": "Scans a template to produce template metadata.\n\nTemplate-specific metadata are stored in the object returned, and node-\nspecific metadata are stored in objects in its flattened `nodeInfoList`\narray.  Only nodes in the template that were parsed as nodes of\ninterest contain an object in `nodeInfoList`.  Each `nodeInfo` object\ncontains an `index` (`childNodes` index in parent) and optionally\n`parent`, which points to node info of its parent (including its index).\n\nThe template metadata object returned from this method has the following\nstructure (many fields optional):\n\n```js\n  {\n    // Flattened list of node metadata (for nodes that generated metadata)\n    nodeInfoList: [\n      {\n        // `id` attribute for any nodes with id's for generating `$` map\n        id: {string},\n        // `on-event=\"handler\"` metadata\n        events: [\n          {\n            name: {string},   // event name\n            value: {string},  // handler method name\n          }, ...\n        ],\n        // Notes when the template contained a `<slot>` for shady DOM\n        // optimization purposes\n        hasInsertionPoint: {boolean},\n        // For nested `<template>`` nodes, nested template metadata\n        templateInfo: {object}, // nested template metadata\n        // Metadata to allow efficient retrieval of instanced node\n        // corresponding to this metadata\n        parentInfo: {number},   // reference to parent nodeInfo>\n        parentIndex: {number},  // index in parent's `childNodes` collection\n        infoIndex: {number},    // index of this `nodeInfo` in `templateInfo.nodeInfoList`\n      },\n      ...\n    ],\n    // When true, the template had the `strip-whitespace` attribute\n    // or was nested in a template with that setting\n    stripWhitespace: {boolean},\n    // For nested templates, nested template content is moved into\n    // a document fragment stored here; this is an optimization to\n    // avoid the cost of nested template cloning\n    content: {DocumentFragment}\n  }\n```\n\nThis method kicks off a recursive treewalk as follows:\n\n```\n   _parseTemplate <---------------------+\n     _parseTemplateContent              |\n       _parseTemplateNode  <------------|--+\n         _parseTemplateNestedTemplate --+  |\n         _parseTemplateChildNodes ---------+\n         _parseTemplateNodeAttributes\n           _parseTemplateNodeAttribute\n\n```\n\nThese methods may be overridden to add custom metadata about templates\nto either `templateInfo` or `nodeInfo`.\n\nNote that this method may be destructive to the template, in that\ne.g. event annotations may be removed after being noted in the\ntemplate metadata.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 197,
-              "column": 6
-            },
-            "end": {
-              "line": 208,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "!HTMLTemplateElement",
-              "description": "Template to parse"
-            },
-            {
-              "name": "outerTemplateInfo",
-              "type": "TemplateInfo=",
-              "description": "Template metadata from the outer\n  template, for parsing nested templates"
-            }
-          ],
-          "return": {
-            "type": "!TemplateInfo",
-            "desc": "Parsed template metadata"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateContent",
-          "description": "Overrides `PropertyAccessors` to add map of dynamic functions on\ntemplate info, for consumption by `PropertyEffects` template binding\ncode. This map determines which method templates should have accessors\ncreated for them.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 815,
-              "column": 6
-            },
-            "end": {
-              "line": 818,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template"
-            },
-            {
-              "name": "templateInfo"
-            },
-            {
-              "name": "nodeInfo"
-            }
-          ],
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_parseTemplateNode",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from `TextNode`'s' `textContent`.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2442,
-              "column": 6
-            },
-            "end": {
-              "line": 2456,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseTemplateChildNodes",
-          "description": "Parses template child nodes for the given root node.\n\nThis method also wraps whitelisted legacy template extensions\n(`is=\"dom-if\"` and `is=\"dom-repeat\"`) with their equivalent element\nwrappers, collapses text nodes, and strips whitespace from the template\nif the `templateInfo.stripWhitespace` setting was provided.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 258,
-              "column": 6
-            },
-            "end": {
-              "line": 295,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "root",
-              "type": "Node",
-              "description": "Root node whose `childNodes` will be parsed"
-            },
-            {
-              "name": "templateInfo",
-              "type": "!TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "!NodeInfo",
-              "description": "Node metadata for current template."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateNestedTemplate",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nbinding the properties that a nested template depends on to the template\nas `_host_<property>`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2529,
-              "column": 6
-            },
-            "end": {
-              "line": 2539,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Node",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseTemplateNodeAttributes",
-          "description": "Parses template node attributes and adds node metadata to `nodeInfo`\nfor nodes of interest.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 333,
-              "column": 6
-            },
-            "end": {
-              "line": 342,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template."
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "_parseTemplateNodeAttribute",
-          "description": "Overrides default `TemplateStamp` implementation to add support for\nparsing bindings from attributes.  A `bindings`\narray is added to `nodeInfo` and populated with binding metadata\nwith information capturing the binding target, and a `parts` array\nwith one or more metadata objects capturing the source(s) of the\nbinding.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2477,
-              "column": 6
-            },
-            "end": {
-              "line": 2513,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "node",
-              "type": "Element",
-              "description": "Node to parse"
-            },
-            {
-              "name": "templateInfo",
-              "type": "TemplateInfo",
-              "description": "Template metadata for current template"
-            },
-            {
-              "name": "nodeInfo",
-              "type": "NodeInfo",
-              "description": "Node metadata for current template node"
-            },
-            {
-              "name": "name",
-              "type": "string",
-              "description": "Attribute name"
-            },
-            {
-              "name": "value",
-              "type": "string",
-              "description": "Attribute value"
-            }
-          ],
-          "return": {
-            "type": "boolean",
-            "desc": "`true` if the visited node added node-specific\n  metadata to `nodeInfo`"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_contentForTemplate",
-          "description": "Returns the `content` document fragment for a given template.\n\nFor nested templates, Polymer performs an optimization to cache nested\ntemplate content to avoid the cost of cloning deeply nested templates.\nThis method retrieves the cached content for a given template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/template-stamp.html",
-            "start": {
-              "line": 388,
-              "column": 6
-            },
-            "end": {
-              "line": 391,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "HTMLTemplateElement",
-              "description": "Template to retrieve `content` for"
-            }
-          ],
-          "return": {
-            "type": "DocumentFragment",
-            "desc": "Content fragment"
-          },
-          "inheritedFrom": "Polymer.TemplateStamp"
-        },
-        {
-          "name": "createPropertiesForAttributes",
-          "description": "Generates property accessors for all attributes in the standard\nstatic `observedAttributes` array.\n\nAttribute names are mapped to property names using the `dash-case` to\n`camelCase` convention",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-accessors.html",
-            "start": {
-              "line": 115,
-              "column": 6
-            },
-            "end": {
-              "line": 120,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyAccessors"
-        },
-        {
-          "name": "addPropertyEffect",
-          "description": "Ensures an accessor exists for the specified property, and adds\nto a list of \"property effects\" that will run when the accessor for\nthe specified property is set.  Effects are grouped by \"type\", which\nroughly corresponds to a phase in effect processing.  The effect\nmetadata should be in the following form:\n\n    {\n      fn: effectFunction, // Reference to function to call to perform effect\n      info: { ... }       // Effect metadata passed to function\n      trigger: {          // Optional triggering metadata; if not provided\n        name: string      // the property is treated as a wildcard\n        structured: boolean\n        wildcard: boolean\n      }\n    }\n\nEffects are called from `_propertiesChanged` in the following order by\ntype:\n\n1. COMPUTE\n2. PROPAGATE\n3. REFLECT\n4. OBSERVE\n5. NOTIFY\n\nEffect functions are called with the following signature:\n\n    effectFunction(inst, path, props, oldProps, info, hasPaths)",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2163,
-              "column": 6
-            },
-            "end": {
-              "line": 2165,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "type",
-              "type": "string",
-              "description": "Effect type, from this.PROPERTY_EFFECT_TYPES"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createPropertyObserver",
-          "description": "Creates a single-property observer for the given property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2177,
-              "column": 6
-            },
-            "end": {
-              "line": 2179,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "method",
-              "type": "(string|function (*, *))",
-              "description": "Function or name of observer method to call"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "boolean=",
-              "description": "Whether the method name should be included as\n  a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createMethodObserver",
-          "description": "Creates a multi-property \"method observer\" based on the provided\nexpression, which should be a string in the form of a normal JavaScript\nfunction signature: `'methodName(arg1, [..., argn])'`.  Each argument\nshould correspond to a property or path in the context of this\nprototype (or instance), or may be a literal string or number.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2194,
-              "column": 6
-            },
-            "end": {
-              "line": 2196,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating"
-            }
-          ],
-          "return": {
-            "type": "void",
-            "desc": "whether method names should be included as a dependency to the effect."
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createNotifyingProperty",
-          "description": "Causes the setter for the given property to dispatch `<property>-changed`\nevents to notify of changes to the property.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2206,
-              "column": 6
-            },
-            "end": {
-              "line": 2208,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createReadOnlyProperty",
-          "description": "Creates a read-only accessor for the given property.\n\nTo set the property, use the protected `_setProperty` API.\nTo create a custom protected setter (e.g. `_setMyProp()` for\nproperty `myProp`), pass `true` for `protectedSetter`.\n\nNote, if the property will have other property effects, this method\nshould be called first, before adding other effects.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2226,
-              "column": 6
-            },
-            "end": {
-              "line": 2228,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            },
-            {
-              "name": "protectedSetter",
-              "type": "boolean=",
-              "description": "Creates a custom protected setter\n  when `true`."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createReflectedProperty",
-          "description": "Causes the setter for the given property to reflect the property value\nto a (dash-cased) attribute of the same name.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2238,
-              "column": 6
-            },
-            "end": {
-              "line": 2240,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Property name"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "createComputedProperty",
-          "description": "Creates a computed property whose value is set to the result of the\nmethod described by the given `expression` each time one or more\narguments to the method changes.  The expression should be a string\nin the form of a normal JavaScript function signature:\n`'methodName(arg1, [..., argn])'`",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2256,
-              "column": 6
-            },
-            "end": {
-              "line": 2258,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "property",
-              "type": "string",
-              "description": "Name of computed property to set"
-            },
-            {
-              "name": "expression",
-              "type": "string",
-              "description": "Method expression"
-            },
-            {
-              "name": "dynamicFn",
-              "type": "(boolean|Object)=",
-              "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "bindTemplate",
-          "description": "Parses the provided template to ensure binding effects are created\nfor them, and then ensures property accessors are created for any\ndependent properties in the template.  Binding effects for bound\ntemplates are stored in a linked list on the instance so that\ntemplates can be efficiently stamped and unstamped.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2272,
-              "column": 6
-            },
-            "end": {
-              "line": 2274,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "template",
-              "type": "HTMLTemplateElement",
-              "description": "Template containing binding\n  bindings"
-            }
-          ],
-          "return": {
-            "type": "Object",
-            "desc": "Template metadata object"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_addTemplatePropertyEffect",
-          "description": "Adds a property effect to the given template metadata, which is run\nat the \"propagate\" stage of `_propertiesChanged` when the template\nhas been bound to the element via `_bindTemplate`.\n\nThe `effect` object should match the format in `_addPropertyEffect`.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2338,
-              "column": 6
-            },
-            "end": {
-              "line": 2344,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "templateInfo",
-              "type": "Object",
-              "description": "Template metadata to add effect to"
-            },
-            {
-              "name": "prop",
-              "type": "string",
-              "description": "Property that should trigger the effect"
-            },
-            {
-              "name": "effect",
-              "type": "Object=",
-              "description": "Effect metadata object"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_parseBindings",
-          "description": "Called to parse text in a template (either attribute values or\ntextContent) into binding metadata.\n\nAny overrides of this method should return an array of binding part\nmetadata  representing one or more bindings found in the provided text\nand any \"literal\" text in between.  Any non-literal parts will be passed\nto `_evaluateBinding` when any dependencies change.  The only required\nfields of each \"part\" in the returned array are as follows:\n\n- `dependencies` - Array containing trigger metadata for each property\n  that should trigger the binding to update\n- `literal` - String containing text if the part represents a literal;\n  in this case no `dependencies` are needed\n\nAdditional metadata for use by `_evaluateBinding` may be provided in\neach part object as needed.\n\nThe default implementation handles the following types of bindings\n(one or more may be intermixed with literal strings):\n- Property binding: `[[prop]]`\n- Path binding: `[[object.prop]]`\n- Negated property or path bindings: `[[!prop]]` or `[[!object.prop]]`\n- Two-way property or path bindings (supports negation):\n  `{{prop}}`, `{{object.prop}}`, `{{!prop}}` or `{{!object.prop}}`\n- Inline computed method (supports negation):\n  `[[compute(a, 'literal', b)]]`, `[[!compute(a, 'literal', b)]]`",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2574,
-              "column": 6
-            },
-            "end": {
-              "line": 2639,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "text",
-              "type": "string",
-              "description": "Text to parse from attribute or textContent"
-            },
-            {
-              "name": "templateInfo",
-              "type": "Object",
-              "description": "Current template metadata"
-            }
-          ],
-          "return": {
-            "type": "Array.<!BindingPart>",
-            "desc": "Array of binding part metadata"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "_evaluateBinding",
-          "description": "Called to evaluate a previously parsed binding part based on a set of\none or more changed dependencies.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/property-effects.html",
-            "start": {
-              "line": 2655,
-              "column": 6
-            },
-            "end": {
-              "line": 2672,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "inst",
-              "type": "this",
-              "description": "Element that should be used as scope for\n  binding dependencies"
-            },
-            {
-              "name": "part",
-              "type": "BindingPart",
-              "description": "Binding part metadata"
-            },
-            {
-              "name": "path",
-              "type": "string",
-              "description": "Property/path that triggered this effect"
-            },
-            {
-              "name": "props",
-              "type": "Object",
-              "description": "Bag of current property changes"
-            },
-            {
-              "name": "oldProps",
-              "type": "Object",
-              "description": "Bag of previous values for changed properties"
-            },
-            {
-              "name": "hasPaths",
-              "type": "boolean",
-              "description": "True with `props` contains one or more paths"
-            }
-          ],
-          "return": {
-            "type": "*",
-            "desc": "Value the binding part evaluated to"
-          },
-          "inheritedFrom": "Polymer.PropertyEffects"
-        },
-        {
-          "name": "finalize",
-          "description": "Called automatically when the first element instance is created to\nensure that class finalization work has been completed.\nMay be called by users to eagerly perform class finalization work\nprior to the creation of the first element instance.\n\nClass finalization work generally includes meta-programming such as\ncreating property accessors and any property effect metadata needed for\nthe features used.",
-          "privacy": "public",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 482,
-              "column": 6
-            },
-            "end": {
-              "line": 486,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_processStyleText",
-          "description": "Gather style text for a style element in the template.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 628,
-              "column": 6
-            },
-            "end": {
-              "line": 630,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "cssText",
-              "type": "string",
-              "description": "Text containing styling to process"
-            },
-            {
-              "name": "baseURI",
-              "type": "string",
-              "description": "Base URI to rebase CSS paths against"
-            }
-          ],
-          "return": {
-            "type": "string",
-            "desc": "The processed CSS text"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        },
-        {
-          "name": "_finalizeTemplate",
-          "description": "Configures an element `proto` to function with a given `template`.\nThe element name `is` and extends `ext` must be specified for ShadyCSS\nstyle scoping.",
-          "privacy": "protected",
-          "sourceRange": {
-            "file": "../../bower_components/polymer/lib/mixins/element-mixin.html",
-            "start": {
-              "line": 641,
-              "column": 6
-            },
-            "end": {
-              "line": 652,
-              "column": 7
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "is",
-              "type": "string",
-              "description": "Tag name (or type extension name) for this element"
-            }
-          ],
-          "return": {
-            "type": "void"
-          },
-          "inheritedFrom": "Polymer.ElementMixin"
-        }
-      ],
-      "demos": [],
-      "metadata": {},
-      "sourceRange": {
-        "start": {
-          "line": 64,
-          "column": 8
-        },
-        "end": {
-          "line": 251,
-          "column": 9
-        }
-      },
-      "privacy": "public",
-      "superclass": "HTMLElement",
-      "name": "AnimadListHeader",
-      "attributes": [
-        {
-          "name": "search",
-          "description": "Query for which the user was searching",
-          "sourceRange": {
-            "start": {
-              "line": 72,
-              "column": 11
-            },
-            "end": {
-              "line": 76,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "selected-filters",
-          "description": "selectedFilters enthält die Information über alle ausgewählten Filter.",
-          "sourceRange": {
-            "start": {
-              "line": 80,
-              "column": 14
-            },
-            "end": {
-              "line": 85,
-              "column": 15
-            }
-          },
-          "metadata": {},
-          "type": "Array"
-        },
-        {
-          "name": "all-filters",
-          "description": "All filters from which the user can choose",
-          "sourceRange": {
-            "start": {
-              "line": 89,
-              "column": 11
-            },
-            "end": {
-              "line": 89,
-              "column": 29
-            }
-          },
-          "metadata": {},
-          "type": "Object"
-        },
-        {
-          "name": "hide-header",
-          "description": "Wether to hide the whole list header. Set attribute \"hide-header\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 93,
-              "column": 18
-            },
-            "end": {
-              "line": 93,
-              "column": 37
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "hide-filter-button",
-          "description": "Whether to hide the Filter button. Set attribute \"hide-filter-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 97,
-              "column": 11
-            },
-            "end": {
-              "line": 100,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "hide-delete-button",
-          "description": "Whether to hide the Delete button. Set attribute \"hide-delete-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 104,
-              "column": 11
-            },
-            "end": {
-              "line": 107,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "hide-new-button",
-          "description": "Whether to hide the New button. Set attribute \"hide-new-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 111,
-              "column": 11
-            },
-            "end": {
-              "line": 114,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "disable-filter-button",
-          "description": "Whether to disable the Filter button. Set attribute \"disable-filter-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 118,
-              "column": 11
-            },
-            "end": {
-              "line": 121,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "disable-delete-button",
-          "description": "Whether to disable the Delete button. Set attribute \"disable-delete-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 125,
-              "column": 11
-            },
-            "end": {
-              "line": 128,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "disable-new-button",
-          "description": "Whether to disable the New button. Set attribute \"disable-new-button\" to do so.",
-          "sourceRange": {
-            "start": {
-              "line": 132,
-              "column": 11
-            },
-            "end": {
-              "line": 135,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "icon",
-          "description": "Icon shown in the search background",
-          "sourceRange": {
-            "start": {
-              "line": 139,
-              "column": 11
-            },
-            "end": {
-              "line": 142,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "placeholder-search",
-          "description": "Text shown in the search box if the user didn't enter any query",
-          "sourceRange": {
-            "start": {
-              "line": 146,
-              "column": 11
-            },
-            "end": {
-              "line": 149,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "placeholder-delete",
-          "description": "Text for Delete button if the user didn't enter any query",
-          "sourceRange": {
-            "start": {
-              "line": 153,
-              "column": 11
-            },
-            "end": {
-              "line": 156,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "placeholder-new",
-          "description": "Text for New button if the user didn't enter any query",
-          "sourceRange": {
-            "start": {
-              "line": 160,
-              "column": 11
-            },
-            "end": {
-              "line": 163,
-              "column": 12
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        },
-        {
-          "name": "show-results",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "sourceRange": {
-            "start": {
-              "line": 174,
-              "column": 14
-            },
-            "end": {
-              "line": 177,
-              "column": 15
-            }
-          },
-          "metadata": {},
-          "type": "boolean"
-        },
-        {
-          "name": "results-text",
-          "description": "Toggles visibility of collapsable element for filter selection",
-          "sourceRange": {
-            "start": {
-              "line": 181,
-              "column": 14
-            },
-            "end": {
-              "line": 184,
-              "column": 15
-            }
-          },
-          "metadata": {},
-          "type": "string"
-        }
-      ],
-      "events": [
-        {
-          "type": "CustomEvent",
-          "name": "search-changed",
-          "description": "Fired when the `search` property changes.",
-          "metadata": {}
-        }
-      ],
-      "styling": {
-        "cssVariables": [],
-        "selectors": []
-      },
-      "slots": [],
-      "tagname": "animad-list-header"
     },
     {
       "description": "GENERATOR pattern: [DOMAINNAME]-[ENTITYNAME]-list\n\n`animad-enclosures-list` ist eine Liste zur Anzeige von Gehegen, die über die angegebene [url](#/elements/animad-enclosures-list#property-url)\ngesucht werden.\n\nZur Suche können Suchbegriffe eingegeben werden, um die Anzahl der gefundenen Datensätze zu begrenzen. Diese Suchbegriffe können\nauch als Standard für die Liste festgelegt werden.\n\nDie gefundenen Datensätze können sortiert, selektiert und gelöscht werden.\n\nDie Navigation auf die Forms [`<animad-enclosure-create-form>`](#/elements/animad-enclosure-create-form)\nund [`<animad-enclosure-update-form>`](#/elements/animad-enclosure-update-form)\nzur Neuanlage bzw. zum Editieren eines Datensatzes ist möglich.\n\n#### Beispiel:\n\n    <animad-enclosures-list name=\"\"\n      url=\"http://localhost:39146/enclosures\"\n      default-search='name:Elefantenparadies'\n      route=\"{{subroute}}\"\n      edit-path=\"/enclosures-view/edit\"\n      create-path=\"/enclosures-view/create\">\n    </animad-enclosures-list>",
@@ -22013,11 +13523,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
               "column": 15
             }
           },
@@ -22028,18 +13538,18 @@
           "inheritedFrom": "AnimadListBehavior"
         },
         {
-          "name": "_filteredData",
+          "name": "filteredData",
           "type": "Array",
-          "description": "_filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus _filteredData an.",
-          "privacy": "protected",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "privacy": "public",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 26,
+              "line": 36,
               "column": 14
             },
             "end": {
-              "line": 31,
+              "line": 41,
               "column": 15
             }
           },
@@ -22056,11 +13566,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 36,
+              "line": 46,
               "column": 14
             },
             "end": {
-              "line": 41,
+              "line": 51,
               "column": 15
             }
           },
@@ -22078,11 +13588,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -22099,11 +13609,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 81,
+              "line": 91,
               "column": 14
             },
             "end": {
-              "line": 83,
+              "line": 93,
               "column": 15
             }
           },
@@ -22120,11 +13630,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 87,
+              "line": 97,
               "column": 14
             },
             "end": {
-              "line": 92,
+              "line": 102,
               "column": 15
             }
           },
@@ -22142,11 +13652,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 96,
+              "line": 106,
               "column": 14
             },
             "end": {
-              "line": 98,
+              "line": 108,
               "column": 15
             }
           },
@@ -22163,11 +13673,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -22185,11 +13695,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 109,
+              "line": 119,
               "column": 14
             },
             "end": {
-              "line": 112,
+              "line": 122,
               "column": 15
             }
           },
@@ -22207,11 +13717,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 116,
+              "line": 126,
               "column": 14
             },
             "end": {
-              "line": 119,
+              "line": 129,
               "column": 15
             }
           },
@@ -22229,11 +13739,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 125,
+              "line": 135,
               "column": 14
             },
             "end": {
-              "line": 128,
+              "line": 138,
               "column": 15
             }
           },
@@ -22251,11 +13761,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 134,
+              "line": 144,
               "column": 14
             },
             "end": {
-              "line": 137,
+              "line": 147,
               "column": 15
             }
           },
@@ -22273,11 +13783,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 141,
+              "line": 151,
               "column": 14
             },
             "end": {
-              "line": 146,
+              "line": 156,
               "column": 15
             }
           },
@@ -22295,11 +13805,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 148,
+              "line": 158,
               "column": 14
             },
             "end": {
-              "line": 151,
+              "line": 161,
               "column": 15
             }
           },
@@ -22318,11 +13828,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -22340,11 +13850,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -22362,11 +13872,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -22384,11 +13894,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -22406,11 +13916,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -22428,11 +13938,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -22450,11 +13960,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -22472,11 +13982,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -22494,11 +14004,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -22516,11 +14026,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -22538,11 +14048,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -22559,11 +14069,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -22580,11 +14090,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -22602,11 +14112,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -22624,11 +14134,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -22646,11 +14156,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 282,
+              "line": 292,
               "column": 14
             },
             "end": {
-              "line": 284,
+              "line": 294,
               "column": 15
             }
           },
@@ -22667,11 +14177,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 288,
+              "line": 298,
               "column": 14
             },
             "end": {
-              "line": 291,
+              "line": 301,
               "column": 15
             }
           },
@@ -22689,11 +14199,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 296,
+              "line": 306,
               "column": 14
             },
             "end": {
-              "line": 299,
+              "line": 309,
               "column": 15
             }
           },
@@ -22711,11 +14221,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 303,
+              "line": 313,
               "column": 14
             },
             "end": {
-              "line": 306,
+              "line": 316,
               "column": 15
             }
           },
@@ -22733,11 +14243,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 310,
+              "line": 320,
               "column": 14
             },
             "end": {
-              "line": 312,
+              "line": 322,
               "column": 15
             }
           },
@@ -22858,11 +14368,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 326,
+              "line": 336,
               "column": 8
             },
             "end": {
-              "line": 329,
+              "line": 339,
               "column": 9
             }
           },
@@ -22877,11 +14387,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 336,
+              "line": 346,
               "column": 8
             },
             "end": {
-              "line": 366,
+              "line": 376,
               "column": 9
             }
           },
@@ -22894,17 +14404,36 @@
           "inheritedFrom": "AnimadListBehavior"
         },
         {
+          "name": "_onFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "file": "../behaviors/animad-list-behavior.html",
+            "start": {
+              "line": 378,
+              "column": 8
+            },
+            "end": {
+              "line": 384,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": [],
+          "inheritedFrom": "AnimadListBehavior"
+        },
+        {
           "name": "_deselectItems",
           "description": "Deselektiert alle Datensätze",
           "privacy": "protected",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 371,
+              "line": 389,
               "column": 8
             },
             "end": {
-              "line": 379,
+              "line": 397,
               "column": 9
             }
           },
@@ -22923,11 +14452,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 385,
+              "line": 403,
               "column": 8
             },
             "end": {
-              "line": 387,
+              "line": 405,
               "column": 9
             }
           },
@@ -22946,11 +14475,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 393,
+              "line": 411,
               "column": 8
             },
             "end": {
-              "line": 395,
+              "line": 413,
               "column": 9
             }
           },
@@ -22969,11 +14498,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 402,
+              "line": 420,
               "column": 8
             },
             "end": {
-              "line": 404,
+              "line": 422,
               "column": 9
             }
           },
@@ -22992,11 +14521,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 410,
+              "line": 428,
               "column": 8
             },
             "end": {
-              "line": 433,
+              "line": 451,
               "column": 9
             }
           },
@@ -23018,11 +14547,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 440,
+              "line": 458,
               "column": 8
             },
             "end": {
-              "line": 452,
+              "line": 470,
               "column": 9
             }
           },
@@ -23037,11 +14566,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 457,
+              "line": 475,
               "column": 8
             },
             "end": {
-              "line": 462,
+              "line": 480,
               "column": 9
             }
           },
@@ -23060,11 +14589,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 469,
+              "line": 487,
               "column": 8
             },
             "end": {
-              "line": 492,
+              "line": 511,
               "column": 9
             }
           },
@@ -23083,11 +14612,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 498,
+              "line": 517,
               "column": 8
             },
             "end": {
-              "line": 517,
+              "line": 536,
               "column": 9
             }
           },
@@ -23106,11 +14635,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 523,
+              "line": 542,
               "column": 8
             },
             "end": {
-              "line": 539,
+              "line": 558,
               "column": 9
             }
           },
@@ -23146,11 +14675,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 563,
+              "line": 582,
               "column": 8
             },
             "end": {
-              "line": 572,
+              "line": 591,
               "column": 9
             }
           },
@@ -23165,11 +14694,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 577,
+              "line": 596,
               "column": 8
             },
             "end": {
-              "line": 580,
+              "line": 599,
               "column": 9
             }
           },
@@ -23184,11 +14713,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 586,
+              "line": 605,
               "column": 8
             },
             "end": {
-              "line": 615,
+              "line": 635,
               "column": 9
             }
           },
@@ -23205,16 +14734,16 @@
         },
         {
           "name": "_transferCellnameToFieldname",
-          "description": "Wandelt den tabellennamen in den korrespondierenden Backend-Feldnamen um",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 620,
+              "line": 637,
               "column": 8
             },
             "end": {
-              "line": 642,
+              "line": 657,
               "column": 9
             }
           },
@@ -23236,11 +14765,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 648,
+              "line": 663,
               "column": 8
             },
             "end": {
-              "line": 657,
+              "line": 673,
               "column": 9
             }
           },
@@ -23259,11 +14788,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 662,
+              "line": 678,
               "column": 8
             },
             "end": {
-              "line": 688,
+              "line": 705,
               "column": 9
             }
           },
@@ -23282,11 +14811,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 702,
+              "line": 719,
               "column": 8
             },
             "end": {
-              "line": 706,
+              "line": 723,
               "column": 9
             }
           },
@@ -23308,11 +14837,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 711,
+              "line": 728,
               "column": 8
             },
             "end": {
-              "line": 715,
+              "line": 732,
               "column": 9
             }
           },
@@ -23334,11 +14863,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 720,
+              "line": 737,
               "column": 8
             },
             "end": {
-              "line": 724,
+              "line": 741,
               "column": 9
             }
           },
@@ -23572,11 +15101,29 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
+              "column": 15
+            }
+          },
+          "metadata": {},
+          "type": "Array",
+          "inheritedFrom": "AnimadListBehavior"
+        },
+        {
+          "name": "filtered-data",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "sourceRange": {
+            "file": "../behaviors/animad-list-behavior.html",
+            "start": {
+              "line": 36,
+              "column": 14
+            },
+            "end": {
+              "line": 41,
               "column": 15
             }
           },
@@ -23590,11 +15137,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -23608,11 +15155,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -23626,11 +15173,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -23644,11 +15191,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -23662,11 +15209,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -23680,11 +15227,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -23698,11 +15245,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -23716,11 +15263,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -23734,11 +15281,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -23752,11 +15299,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -23770,11 +15317,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -23788,11 +15335,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -23806,11 +15353,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -23824,11 +15371,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -23842,11 +15389,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -23860,11 +15407,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -23878,11 +15425,11 @@
           "sourceRange": {
             "file": "../behaviors/animad-list-behavior.html",
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -23927,7 +15474,15 @@
           "inheritedFrom": "AnimadI18nBehavior"
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "filter-data",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "metadata": {},
+          "inheritedFrom": "AnimadListBehavior"
+        }
+      ],
       "styling": {
         "cssVariables": [],
         "selectors": []
@@ -24508,6 +16063,25 @@
             "polymer": {}
           },
           "defaultValue": "\"animad-enclosures\""
+        },
+        {
+          "name": "backendUrl",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 121,
+              "column": 10
+            },
+            "end": {
+              "line": 123,
+              "column": 11
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
         }
       ],
       "methods": [],
@@ -24520,14 +16094,31 @@
           "column": 4
         },
         "end": {
-          "line": 123,
+          "line": 126,
           "column": 5
         }
       },
       "privacy": "public",
       "superclass": "HTMLElement",
       "name": "AnimadEnclosuresView",
-      "attributes": [],
+      "attributes": [
+        {
+          "name": "backend-url",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 121,
+              "column": 10
+            },
+            "end": {
+              "line": 123,
+              "column": 11
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
       "events": [],
       "styling": {
         "cssVariables": [],
@@ -24547,11 +16138,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 26,
+          "line": 25,
           "column": 8
         },
         "end": {
-          "line": 31,
+          "line": 30,
           "column": 9
         }
       },
@@ -24578,11 +16169,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 23,
+          "line": 22,
           "column": 8
         },
         "end": {
-          "line": 29,
+          "line": 28,
           "column": 9
         }
       },
@@ -28293,11 +19884,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 70,
+              "line": 71,
               "column": 10
             },
             "end": {
-              "line": 73,
+              "line": 74,
               "column": 11
             }
           },
@@ -28313,11 +19904,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 82,
+              "line": 83,
               "column": 10
             },
             "end": {
-              "line": 85,
+              "line": 86,
               "column": 11
             }
           },
@@ -28325,6 +19916,25 @@
             "polymer": {}
           },
           "defaultValue": "\"animad-keepers-formsamples\""
+        },
+        {
+          "name": "backendUrl",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 87,
+              "column": 10
+            },
+            "end": {
+              "line": 89,
+              "column": 11
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
         }
       ],
       "methods": [],
@@ -28333,18 +19943,35 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 58,
+          "line": 59,
           "column": 4
         },
         "end": {
-          "line": 88,
+          "line": 92,
           "column": 5
         }
       },
       "privacy": "public",
       "superclass": "HTMLElement",
       "name": "AnimadKeepersFormsamplesView",
-      "attributes": [],
+      "attributes": [
+        {
+          "name": "backend-url",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 87,
+              "column": 10
+            },
+            "end": {
+              "line": 89,
+              "column": 11
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
       "events": [],
       "styling": {
         "cssVariables": [],
@@ -32768,6 +24395,26 @@
           "metadata": {
             "polymer": {}
           }
+        },
+        {
+          "name": "backendUrl",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 207,
+              "column": 20
+            },
+            "end": {
+              "line": 210,
+              "column": 21
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"http://localhost:8082\""
         }
       ],
       "methods": [
@@ -34645,11 +26292,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 216,
+              "line": 220,
               "column": 12
             },
             "end": {
-              "line": 228,
+              "line": 232,
               "column": 13
             }
           },
@@ -34772,11 +26419,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 230,
+              "line": 234,
               "column": 12
             },
             "end": {
-              "line": 242,
+              "line": 246,
               "column": 13
             }
           },
@@ -34793,11 +26440,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 244,
+              "line": 248,
               "column": 12
             },
             "end": {
-              "line": 254,
+              "line": 258,
               "column": 13
             }
           },
@@ -34814,11 +26461,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 256,
+              "line": 260,
               "column": 12
             },
             "end": {
-              "line": 258,
+              "line": 262,
               "column": 13
             }
           },
@@ -35630,7 +27277,7 @@
           "column": 8
         },
         "end": {
-          "line": 259,
+          "line": 263,
           "column": 9
         }
       },
@@ -35697,6 +27344,22 @@
             "end": {
               "line": 206,
               "column": 36
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "backend-url",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 207,
+              "column": 20
+            },
+            "end": {
+              "line": 210,
+              "column": 21
             }
           },
           "metadata": {},
@@ -35988,6 +27651,20238 @@
       },
       "slots": [],
       "tagname": "animad-enclosure-simple-relation"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "opened",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 119928
+            },
+            "end": {
+              "line": 0,
+              "column": 119990
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "persistent",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 119991
+            },
+            "end": {
+              "line": 0,
+              "column": 120047
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "transitionDuration",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120048
+            },
+            "end": {
+              "line": 0,
+              "column": 120090
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "200"
+        },
+        {
+          "name": "align",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120091
+            },
+            "end": {
+              "line": 0,
+              "column": 120123
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"left\""
+        },
+        {
+          "name": "position",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120124
+            },
+            "end": {
+              "line": 0,
+              "column": 120180
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "swipeOpen",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120181
+            },
+            "end": {
+              "line": 0,
+              "column": 120236
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "noFocusTrap",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120237
+            },
+            "end": {
+              "line": 0,
+              "column": 120272
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "disableSwipe",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120273
+            },
+            "end": {
+              "line": 0,
+              "column": 120309
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_translateOffset",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120489
+            },
+            "end": {
+              "line": 0,
+              "column": 120507
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_trackDetails",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120508
+            },
+            "end": {
+              "line": 0,
+              "column": 120526
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_drawerState",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120527
+            },
+            "end": {
+              "line": 0,
+              "column": 120541
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_boundEscKeydownHandler",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120542
+            },
+            "end": {
+              "line": 0,
+              "column": 120570
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_firstTabStop",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120571
+            },
+            "end": {
+              "line": 0,
+              "column": 120589
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_lastTabStop",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120590
+            },
+            "end": {
+              "line": 0,
+              "column": 120607
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_MIN_FLING_THRESHOLD",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126420
+            },
+            "end": {
+              "line": 0,
+              "column": 126444
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_MIN_TRANSITION_VELOCITY",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126445
+            },
+            "end": {
+              "line": 0,
+              "column": 126473
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_FLING_TIMING_FUNCTION",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126474
+            },
+            "end": {
+              "line": 0,
+              "column": 126531
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_FLING_INITIAL_SLOPE",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126532
+            },
+            "end": {
+              "line": 0,
+              "column": 126556
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_DRAWER_STATE",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126557
+            },
+            "end": {
+              "line": 0,
+              "column": 126639
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120608
+            },
+            "end": {
+              "line": 0,
+              "column": 120909
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120910
+            },
+            "end": {
+              "line": 0,
+              "column": 120999
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "open",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121000
+            },
+            "end": {
+              "line": 0,
+              "column": 121031
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "close",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121032
+            },
+            "end": {
+              "line": 0,
+              "column": 121064
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "toggle",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121065
+            },
+            "end": {
+              "line": 0,
+              "column": 121108
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "getWidth",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121109
+            },
+            "end": {
+              "line": 0,
+              "column": 121190
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_isRTL",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121191
+            },
+            "end": {
+              "line": 0,
+              "column": 121263
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_resetPosition",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121264
+            },
+            "end": {
+              "line": 0,
+              "column": 121482
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_escKeydownHandler",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121483
+            },
+            "end": {
+              "line": 0,
+              "column": 121564
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_track",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121565
+            },
+            "end": {
+              "line": 0,
+              "column": 121772
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_trackStart",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 121773
+            },
+            "end": {
+              "line": 0,
+              "column": 122086
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_trackMove",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 122087
+            },
+            "end": {
+              "line": 0,
+              "column": 122230
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_trackEnd",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 122231
+            },
+            "end": {
+              "line": 0,
+              "column": 122864
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_calculateVelocity",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 122865
+            },
+            "end": {
+              "line": 0,
+              "column": 123070
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_flingDrawer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 123071
+            },
+            "end": {
+              "line": 0,
+              "column": 123733
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_styleTransitionDuration",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 123734
+            },
+            "end": {
+              "line": 0,
+              "column": 123909
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_styleTransitionTimingFunction",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 123910
+            },
+            "end": {
+              "line": 0,
+              "column": 124056
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_translateDrawer",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 124057
+            },
+            "end": {
+              "line": 0,
+              "column": 124309
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_resetDrawerTranslate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 124310
+            },
+            "end": {
+              "line": 0,
+              "column": 124416
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_resetDrawerState",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 124417
+            },
+            "end": {
+              "line": 0,
+              "column": 125157
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "resetLayout",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 125158
+            },
+            "end": {
+              "line": 0,
+              "column": 125211
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_setKeyboardFocusTrap",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 125212
+            },
+            "end": {
+              "line": 0,
+              "column": 125889
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_tabKeydownHandler",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 125890
+            },
+            "end": {
+              "line": 0,
+              "column": 126250
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_openedPersistentChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126251
+            },
+            "end": {
+              "line": 0,
+              "column": 126419
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 0,
+          "column": 119899
+        },
+        "end": {
+          "line": 0,
+          "column": 126640
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "opened",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 119928
+            },
+            "end": {
+              "line": 0,
+              "column": 119990
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "persistent",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 119991
+            },
+            "end": {
+              "line": 0,
+              "column": 120047
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "transition-duration",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120048
+            },
+            "end": {
+              "line": 0,
+              "column": 120090
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120091
+            },
+            "end": {
+              "line": 0,
+              "column": 120123
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "position",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120124
+            },
+            "end": {
+              "line": 0,
+              "column": 120180
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "swipe-open",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120181
+            },
+            "end": {
+              "line": 0,
+              "column": 120236
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-focus-trap",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120237
+            },
+            "end": {
+              "line": 0,
+              "column": 120272
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "disable-swipe",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 120273
+            },
+            "end": {
+              "line": 0,
+              "column": 120309
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "opened-changed",
+          "description": "Fired when the `opened` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 0,
+              "column": 119853
+            },
+            "end": {
+              "line": 0,
+              "column": 119866
+            }
+          }
+        }
+      ],
+      "tagname": "app-drawer"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "queryMatches",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126715
+            },
+            "end": {
+              "line": 0,
+              "column": 126773
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126774
+            },
+            "end": {
+              "line": 0,
+              "column": 126817
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"queryChanged\""
+            }
+          }
+        },
+        {
+          "name": "full",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126818
+            },
+            "end": {
+              "line": 0,
+              "column": 126846
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_boundMQHandler",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126847
+            },
+            "end": {
+              "line": 0,
+              "column": 126918
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_mq",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126919
+            },
+            "end": {
+              "line": 0,
+              "column": 126935
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126937
+            },
+            "end": {
+              "line": 0,
+              "column": 127003
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 127004
+            },
+            "end": {
+              "line": 0,
+              "column": 127039
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_add",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 127040
+            },
+            "end": {
+              "line": 0,
+              "column": 127109
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_remove",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 127110
+            },
+            "end": {
+              "line": 0,
+              "column": 127199
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "queryChanged",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 127200
+            },
+            "end": {
+              "line": 0,
+              "column": 127369
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "queryHandler",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 127370
+            },
+            "end": {
+              "line": 0,
+              "column": 127428
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 0,
+          "column": 126680
+        },
+        "end": {
+          "line": 0,
+          "column": 127429
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "query-matches",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126715
+            },
+            "end": {
+              "line": 0,
+              "column": 126773
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "query",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126774
+            },
+            "end": {
+              "line": 0,
+              "column": 126817
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "full",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 126818
+            },
+            "end": {
+              "line": 0,
+              "column": 126846
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "query-matches-changed",
+          "description": "Fired when the `queryMatches` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-media-query"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "forceNarrow",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131617
+            },
+            "end": {
+              "line": 0,
+              "column": 131652
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "responsiveWidth",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131653
+            },
+            "end": {
+              "line": 0,
+              "column": 131696
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"640px\""
+        },
+        {
+          "name": "narrow",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131697
+            },
+            "end": {
+              "line": 0,
+              "column": 131762
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "openedWhenNarrow",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131763
+            },
+            "end": {
+              "line": 0,
+              "column": 131803
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_drawerPosition",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131804
+            },
+            "end": {
+              "line": 0,
+              "column": 131833
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "drawer",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131906
+            },
+            "end": {
+              "line": 0,
+              "column": 131982
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131983
+            },
+            "end": {
+              "line": 0,
+              "column": 132059
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_clickHandler",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 132060
+            },
+            "end": {
+              "line": 0,
+              "column": 132206
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_updateLayoutStates",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 132207
+            },
+            "end": {
+              "line": 0,
+              "column": 132588
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_narrowChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 132589
+            },
+            "end": {
+              "line": 0,
+              "column": 132660
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onQueryMatchesChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 132661
+            },
+            "end": {
+              "line": 0,
+              "column": 132728
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_computeMediaQuery",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 132729
+            },
+            "end": {
+              "line": 0,
+              "column": 132811
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 0,
+          "column": 131543
+        },
+        "end": {
+          "line": 0,
+          "column": 132812
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "force-narrow",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131617
+            },
+            "end": {
+              "line": 0,
+              "column": 131652
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "responsive-width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131653
+            },
+            "end": {
+              "line": 0,
+              "column": 131696
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "narrow",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131697
+            },
+            "end": {
+              "line": 0,
+              "column": 131762
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "opened-when-narrow",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 131763
+            },
+            "end": {
+              "line": 0,
+              "column": 131803
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "narrow-changed",
+          "description": "Fired when the `narrow` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "drawer",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 0,
+              "column": 131240
+            },
+            "end": {
+              "line": 0,
+              "column": 131283
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 0,
+              "column": 131349
+            },
+            "end": {
+              "line": 0,
+              "column": 131362
+            }
+          }
+        }
+      ],
+      "tagname": "app-drawer-layout"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "condenses",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 268
+            },
+            "end": {
+              "line": 13,
+              "column": 301
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "fixed",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 302
+            },
+            "end": {
+              "line": 13,
+              "column": 331
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "reveals",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 332
+            },
+            "end": {
+              "line": 13,
+              "column": 363
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "shadow",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 364
+            },
+            "end": {
+              "line": 13,
+              "column": 416
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_height",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 477
+            },
+            "end": {
+              "line": 13,
+              "column": 486
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_dHeight",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 487
+            },
+            "end": {
+              "line": 13,
+              "column": 497
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_stickyElTop",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 498
+            },
+            "end": {
+              "line": 13,
+              "column": 512
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_stickyElRef",
+          "type": "object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 513
+            },
+            "end": {
+              "line": 13,
+              "column": 530
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_top",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 531
+            },
+            "end": {
+              "line": 13,
+              "column": 537
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_progress",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 538
+            },
+            "end": {
+              "line": 13,
+              "column": 549
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_wasScrollingDown",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 550
+            },
+            "end": {
+              "line": 13,
+              "column": 570
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_initScrollTop",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 571
+            },
+            "end": {
+              "line": 13,
+              "column": 587
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_initTimestamp",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 588
+            },
+            "end": {
+              "line": 13,
+              "column": 604
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_lastTimestamp",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 605
+            },
+            "end": {
+              "line": 13,
+              "column": 621
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_lastScrollTop",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 622
+            },
+            "end": {
+              "line": 13,
+              "column": 638
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_maxHeaderTop",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 639
+            },
+            "end": {
+              "line": 13,
+              "column": 706
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_stickyEl",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 707
+            },
+            "end": {
+              "line": 13,
+              "column": 1003
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "_configChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 1004
+            },
+            "end": {
+              "line": 13,
+              "column": 1077
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_updateLayoutStates",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 1078
+            },
+            "end": {
+              "line": 13,
+              "column": 1623
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_updateScrollState",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 1624
+            },
+            "end": {
+              "line": 13,
+              "column": 2623
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_mayMove",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 2624
+            },
+            "end": {
+              "line": 13,
+              "column": 2679
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "willCondense",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 2680
+            },
+            "end": {
+              "line": 13,
+              "column": 2743
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "isOnScreen",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 2744
+            },
+            "end": {
+              "line": 13,
+              "column": 2814
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "isContentBelow",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 2815
+            },
+            "end": {
+              "line": 13,
+              "column": 2932
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_transformHeader",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 2933
+            },
+            "end": {
+              "line": 13,
+              "column": 3133
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_clamp",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 3134
+            },
+            "end": {
+              "line": 13,
+              "column": 3190
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            }
+          ]
+        },
+        {
+          "name": "_ensureBgContainers",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 3191
+            },
+            "end": {
+              "line": 13,
+              "column": 3658
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getDOMRef",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 3659
+            },
+            "end": {
+              "line": 13,
+              "column": 4033
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "getScrollState",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 4034
+            },
+            "end": {
+              "line": 13,
+              "column": 4106
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 13,
+          "column": 168
+        },
+        "end": {
+          "line": 13,
+          "column": 4107
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "condenses",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 268
+            },
+            "end": {
+              "line": 13,
+              "column": 301
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "fixed",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 302
+            },
+            "end": {
+              "line": 13,
+              "column": 331
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "reveals",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 332
+            },
+            "end": {
+              "line": 13,
+              "column": 363
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "shadow",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 13,
+              "column": 364
+            },
+            "end": {
+              "line": 13,
+              "column": 416
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 13,
+              "column": 112
+            },
+            "end": {
+              "line": 13,
+              "column": 135
+            }
+          }
+        }
+      ],
+      "tagname": "app-header"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "hasScrollingRegion",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 14,
+              "column": 480
+            },
+            "end": {
+              "line": 14,
+              "column": 544
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "header",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 14,
+              "column": 604
+            },
+            "end": {
+              "line": 14,
+              "column": 680
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "_updateLayoutStates",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 14,
+              "column": 681
+            },
+            "end": {
+              "line": 14,
+              "column": 1311
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 14,
+          "column": 406
+        },
+        "end": {
+          "line": 14,
+          "column": 1312
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "has-scrolling-region",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 14,
+              "column": 480
+            },
+            "end": {
+              "line": 14,
+              "column": 544
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "header",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 14,
+              "column": 284
+            },
+            "end": {
+              "line": 14,
+              "column": 327
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 14,
+              "column": 354
+            },
+            "end": {
+              "line": 14,
+              "column": 367
+            }
+          }
+        }
+      ],
+      "tagname": "app-header-layout"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 317
+        },
+        "end": {
+          "line": 15,
+          "column": 335
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 15,
+              "column": 277
+            },
+            "end": {
+              "line": 15,
+              "column": 290
+            }
+          }
+        }
+      ],
+      "tagname": "app-toolbar"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "path",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 853
+            },
+            "end": {
+              "line": 15,
+              "column": 958
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "query",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 959
+            },
+            "end": {
+              "line": 15,
+              "column": 1045
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "hash",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1046
+            },
+            "end": {
+              "line": 15,
+              "column": 1156
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "dwellTime",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1157
+            },
+            "end": {
+              "line": 15,
+              "column": 1190
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "2000"
+        },
+        {
+          "name": "urlSpaceRegex",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1191
+            },
+            "end": {
+              "line": 15,
+              "column": 1227
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "_urlSpaceRegExp",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1228
+            },
+            "end": {
+              "line": 15,
+              "column": 1283
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "_lastChangedAt",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1284
+            },
+            "end": {
+              "line": 15,
+              "column": 1312
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_initialized",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1313
+            },
+            "end": {
+              "line": 15,
+              "column": 1349
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1351
+            },
+            "end": {
+              "line": 15,
+              "column": 1377
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1422
+            },
+            "end": {
+              "line": 15,
+              "column": 1473
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1474
+            },
+            "end": {
+              "line": 15,
+              "column": 1798
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1799
+            },
+            "end": {
+              "line": 15,
+              "column": 2046
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_hashChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 2047
+            },
+            "end": {
+              "line": 15,
+              "column": 2142
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_urlChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 2143
+            },
+            "end": {
+              "line": 15,
+              "column": 2359
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getUrl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 2360
+            },
+            "end": {
+              "line": 15,
+              "column": 2581
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_updateUrl",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 2582
+            },
+            "end": {
+              "line": 15,
+              "column": 3132
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_globalOnClick",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 3133
+            },
+            "end": {
+              "line": 15,
+              "column": 3355
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_getSameOriginLinkHref",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 3356
+            },
+            "end": {
+              "line": 15,
+              "column": 4219
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_makeRegExp",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4220
+            },
+            "end": {
+              "line": 15,
+              "column": 4261
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 821
+        },
+        "end": {
+          "line": 15,
+          "column": 4262
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "path",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 853
+            },
+            "end": {
+              "line": 15,
+              "column": 958
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "query",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 959
+            },
+            "end": {
+              "line": 15,
+              "column": 1045
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "hash",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1046
+            },
+            "end": {
+              "line": 15,
+              "column": 1156
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "dwell-time",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1157
+            },
+            "end": {
+              "line": 15,
+              "column": 1190
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "url-space-regex",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 1191
+            },
+            "end": {
+              "line": 15,
+              "column": 1227
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "path-changed",
+          "description": "Fired when the `path` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "query-changed",
+          "description": "Fired when the `query` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "hash-changed",
+          "description": "Fired when the `hash` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-location"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "paramsString",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4342
+            },
+            "end": {
+              "line": 15,
+              "column": 4409
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"paramsStringChanged\""
+            }
+          }
+        },
+        {
+          "name": "paramsObject",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4410
+            },
+            "end": {
+              "line": 15,
+              "column": 4473
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "_dontReact",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4474
+            },
+            "end": {
+              "line": 15,
+              "column": 4508
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4510
+            },
+            "end": {
+              "line": 15,
+              "column": 4536
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "paramsStringChanged",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4587
+            },
+            "end": {
+              "line": 15,
+              "column": 4712
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "paramsObjectChanged",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4713
+            },
+            "end": {
+              "line": 15,
+              "column": 4879
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_encodeParams",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4880
+            },
+            "end": {
+              "line": 15,
+              "column": 5068
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_decodeParams",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 5069
+            },
+            "end": {
+              "line": 15,
+              "column": 5271
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 4306
+        },
+        "end": {
+          "line": 15,
+          "column": 5272
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "params-string",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4342
+            },
+            "end": {
+              "line": 15,
+              "column": 4409
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "params-object",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 4410
+            },
+            "end": {
+              "line": 15,
+              "column": 4473
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "params-string-changed",
+          "description": "Fired when the `paramsString` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "params-object-changed",
+          "description": "Fired when the `paramsObject` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-query-params"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "route",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6466
+            },
+            "end": {
+              "line": 15,
+              "column": 6495
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "useHashAsPath",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6496
+            },
+            "end": {
+              "line": 15,
+              "column": 6533
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "urlSpaceRegex",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6534
+            },
+            "end": {
+              "line": 15,
+              "column": 6571
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "__queryParams",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6572
+            },
+            "end": {
+              "line": 15,
+              "column": 6599
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "__path",
+          "type": "string",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6600
+            },
+            "end": {
+              "line": 15,
+              "column": 6620
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "__query",
+          "type": "string",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6621
+            },
+            "end": {
+              "line": 15,
+              "column": 6642
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "__hash",
+          "type": "string",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6643
+            },
+            "end": {
+              "line": 15,
+              "column": 6663
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "path",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6664
+            },
+            "end": {
+              "line": 15,
+              "column": 6709
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"__onPathChanged\""
+            }
+          }
+        },
+        {
+          "name": "_isReady",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6710
+            },
+            "end": {
+              "line": 15,
+              "column": 6733
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6845
+            },
+            "end": {
+              "line": 15,
+              "column": 6879
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "__computeRoutePath",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6880
+            },
+            "end": {
+              "line": 15,
+              "column": 6963
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "__onPathChanged",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6964
+            },
+            "end": {
+              "line": 15,
+              "column": 7071
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 6435
+        },
+        "end": {
+          "line": 15,
+          "column": 7072
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "route",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6466
+            },
+            "end": {
+              "line": 15,
+              "column": 6495
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "use-hash-as-path",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6496
+            },
+            "end": {
+              "line": 15,
+              "column": 6533
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "url-space-regex",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6534
+            },
+            "end": {
+              "line": 15,
+              "column": 6571
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "path",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 6664
+            },
+            "end": {
+              "line": 15,
+              "column": 6709
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "route-changed",
+          "description": "Fired when the `route` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "url-space-regex-changed",
+          "description": "Fired when the `urlSpaceRegex` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "app-location"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "route",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7169
+            },
+            "end": {
+              "line": 15,
+              "column": 7198
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "pattern",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7199
+            },
+            "end": {
+              "line": 15,
+              "column": 7220
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "data",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7221
+            },
+            "end": {
+              "line": 15,
+              "column": 7276
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "queryParams",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7277
+            },
+            "end": {
+              "line": 15,
+              "column": 7339
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "tail",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7340
+            },
+            "end": {
+              "line": 15,
+              "column": 7435
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "active",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7436
+            },
+            "end": {
+              "line": 15,
+              "column": 7479
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "_queryParamsUpdating",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7480
+            },
+            "end": {
+              "line": 15,
+              "column": 7524
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_matched",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7525
+            },
+            "end": {
+              "line": 15,
+              "column": 7556
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7806
+            },
+            "end": {
+              "line": 15,
+              "column": 7943
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "__routeQueryParamsChanged",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7944
+            },
+            "end": {
+              "line": 15,
+              "column": 8365
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "__tailQueryParamsChanged",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 8366
+            },
+            "end": {
+              "line": 15,
+              "column": 8481
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "__queryParamsChanged",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 8482
+            },
+            "end": {
+              "line": 15,
+              "column": 8592
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "__resetProperties",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 8593
+            },
+            "end": {
+              "line": 15,
+              "column": 8661
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "__tryToMatch",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 8662
+            },
+            "end": {
+              "line": 15,
+              "column": 9426
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "__tailPathChanged",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 9427
+            },
+            "end": {
+              "line": 15,
+              "column": 9562
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "__updatePathOnDataChange",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 9563
+            },
+            "end": {
+              "line": 15,
+              "column": 9719
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "__getLink",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 9720
+            },
+            "end": {
+              "line": 15,
+              "column": 10051
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "__setMulti",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 10052
+            },
+            "end": {
+              "line": 15,
+              "column": 10376
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 7141
+        },
+        "end": {
+          "line": 15,
+          "column": 10377
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "route",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7169
+            },
+            "end": {
+              "line": 15,
+              "column": 7198
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "pattern",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7199
+            },
+            "end": {
+              "line": 15,
+              "column": 7220
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "data",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7221
+            },
+            "end": {
+              "line": 15,
+              "column": 7276
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "query-params",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7277
+            },
+            "end": {
+              "line": 15,
+              "column": 7339
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "tail",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7340
+            },
+            "end": {
+              "line": 15,
+              "column": 7435
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "active",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 7436
+            },
+            "end": {
+              "line": 15,
+              "column": 7479
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "route-changed",
+          "description": "Fired when the `route` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "data-changed",
+          "description": "Fired when the `data` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "query-params-changed",
+          "description": "Fired when the `queryParams` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "tail-changed",
+          "description": "Fired when the `tail` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "active-changed",
+          "description": "Fired when the `active` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "app-route"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "activateEvent",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 15497
+            },
+            "end": {
+              "line": 15,
+              "column": 15535
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        }
+      ],
+      "methods": [
+        {
+          "name": "_selectedPageChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 15582
+            },
+            "end": {
+              "line": 15,
+              "column": 15644
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 15395
+        },
+        "end": {
+          "line": 15,
+          "column": 15645
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "activate-event",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 15497
+            },
+            "end": {
+              "line": 15,
+              "column": 15535
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 15,
+              "column": 15355
+            },
+            "end": {
+              "line": 15,
+              "column": 15368
+            }
+          }
+        }
+      ],
+      "tagname": "iron-pages"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 17657
+        },
+        "end": {
+          "line": 15,
+          "column": 17725
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-selector"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "type",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18331
+            },
+            "end": {
+              "line": 15,
+              "column": 18365
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"default\""
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18366
+            },
+            "end": {
+              "line": 15,
+              "column": 18383
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18384
+            },
+            "end": {
+              "line": 15,
+              "column": 18413
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "self",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18414
+            },
+            "end": {
+              "line": 15,
+              "column": 18457
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_selfChanged\""
+            }
+          }
+        },
+        {
+          "name": "__meta",
+          "type": "boolean",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18458
+            },
+            "end": {
+              "line": 15,
+              "column": 18522
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18524
+            },
+            "end": {
+              "line": 15,
+              "column": 18550
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "list",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18711
+            },
+            "end": {
+              "line": 15,
+              "column": 18759
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "__computeMeta",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18551
+            },
+            "end": {
+              "line": 15,
+              "column": 18710
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            }
+          ]
+        },
+        {
+          "name": "_selfChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18760
+            },
+            "end": {
+              "line": 15,
+              "column": 18806
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "byKey",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18807
+            },
+            "end": {
+              "line": 15,
+              "column": 18883
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 18303
+        },
+        "end": {
+          "line": 15,
+          "column": 18884
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "type",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18331
+            },
+            "end": {
+              "line": 15,
+              "column": 18365
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "key",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18366
+            },
+            "end": {
+              "line": 15,
+              "column": 18383
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18384
+            },
+            "end": {
+              "line": 15,
+              "column": 18413
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "self",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 18414
+            },
+            "end": {
+              "line": 15,
+              "column": 18457
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "value-changed",
+          "description": "Fired when the `value` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-meta"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "icon",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19360
+            },
+            "end": {
+              "line": 15,
+              "column": 19378
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "theme",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19379
+            },
+            "end": {
+              "line": 15,
+              "column": 19398
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "src",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19399
+            },
+            "end": {
+              "line": 15,
+              "column": 19416
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_meta",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19417
+            },
+            "end": {
+              "line": 15,
+              "column": 19480
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_DEFAULT_ICONSET",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19624
+            },
+            "end": {
+              "line": 15,
+              "column": 19648
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "_iconChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19649
+            },
+            "end": {
+              "line": 15,
+              "column": 19790
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_srcChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19791
+            },
+            "end": {
+              "line": 15,
+              "column": 19833
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_usesIconset",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19834
+            },
+            "end": {
+              "line": 15,
+              "column": 19886
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_updateIcon",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19887
+            },
+            "end": {
+              "line": 15,
+              "column": 20597
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 15,
+          "column": 19332
+        },
+        "end": {
+          "line": 15,
+          "column": 20598
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "icon",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19360
+            },
+            "end": {
+              "line": 15,
+              "column": 19378
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "theme",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19379
+            },
+            "end": {
+              "line": 15,
+              "column": 19398
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "src",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 15,
+              "column": 19399
+            },
+            "end": {
+              "line": 15,
+              "column": 19416
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-icon"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "initialOpacity",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 4925
+            },
+            "end": {
+              "line": 22,
+              "column": 4964
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "0.25"
+        },
+        {
+          "name": "opacityDecayVelocity",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 4965
+            },
+            "end": {
+              "line": 22,
+              "column": 5009
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "0.8"
+        },
+        {
+          "name": "recenters",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5010
+            },
+            "end": {
+              "line": 22,
+              "column": 5043
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "center",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5044
+            },
+            "end": {
+              "line": 22,
+              "column": 5074
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "ripples",
+          "type": "Array",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5075
+            },
+            "end": {
+              "line": 22,
+              "column": 5122
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "animating",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5123
+            },
+            "end": {
+              "line": 22,
+              "column": 5190
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "holdDown",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5191
+            },
+            "end": {
+              "line": 22,
+              "column": 5251
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_holdDownChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "noink",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5252
+            },
+            "end": {
+              "line": 22,
+              "column": 5281
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_animating",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5282
+            },
+            "end": {
+              "line": 22,
+              "column": 5307
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_boundAnimate",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5308
+            },
+            "end": {
+              "line": 22,
+              "column": 5386
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "keyBindings",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5429
+            },
+            "end": {
+              "line": 22,
+              "column": 5540
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "target",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5388
+            },
+            "end": {
+              "line": 22,
+              "column": 5428
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "shouldKeepAnimating",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5917
+            },
+            "end": {
+              "line": 22,
+              "column": 6039
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5541
+            },
+            "end": {
+              "line": 22,
+              "column": 5760
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5761
+            },
+            "end": {
+              "line": 22,
+              "column": 5916
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "simulatedRipple",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6040
+            },
+            "end": {
+              "line": 22,
+              "column": 6131
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "uiDownAction",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6132
+            },
+            "end": {
+              "line": 22,
+              "column": 6188
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "downAction",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6189
+            },
+            "end": {
+              "line": 22,
+              "column": 6349
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "uiUpAction",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6350
+            },
+            "end": {
+              "line": 22,
+              "column": 6402
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "upAction",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6403
+            },
+            "end": {
+              "line": 22,
+              "column": 6524
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "onAnimationComplete",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6525
+            },
+            "end": {
+              "line": 22,
+              "column": 6647
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "addRipple",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6648
+            },
+            "end": {
+              "line": 22,
+              "column": 6843
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "removeRipple",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6844
+            },
+            "end": {
+              "line": 22,
+              "column": 6987
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "animate",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 6988
+            },
+            "end": {
+              "line": 22,
+              "column": 7341
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onEnterKeydown",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 7342
+            },
+            "end": {
+              "line": 22,
+              "column": 7419
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onSpaceKeydown",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 7420
+            },
+            "end": {
+              "line": 22,
+              "column": 7467
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onSpaceKeyup",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 7468
+            },
+            "end": {
+              "line": 22,
+              "column": 7511
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_holdDownChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 7512
+            },
+            "end": {
+              "line": 22,
+              "column": 7593
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 4853
+        },
+        "end": {
+          "line": 22,
+          "column": 7594
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "initial-opacity",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 4925
+            },
+            "end": {
+              "line": 22,
+              "column": 4964
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "opacity-decay-velocity",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 4965
+            },
+            "end": {
+              "line": 22,
+              "column": 5009
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "recenters",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5010
+            },
+            "end": {
+              "line": 22,
+              "column": 5043
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "center",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5044
+            },
+            "end": {
+              "line": 22,
+              "column": 5074
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "ripples",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5075
+            },
+            "end": {
+              "line": 22,
+              "column": 5122
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "animating",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5123
+            },
+            "end": {
+              "line": 22,
+              "column": 5190
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "hold-down",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5191
+            },
+            "end": {
+              "line": 22,
+              "column": 5251
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "noink",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 5252
+            },
+            "end": {
+              "line": 22,
+              "column": 5281
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-ripple"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19010
+            },
+            "end": {
+              "line": 22,
+              "column": 19053
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "src",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19109
+            },
+            "end": {
+              "line": 22,
+              "column": 19126
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "icon",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19127
+            },
+            "end": {
+              "line": 22,
+              "column": 19145
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "alt",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19146
+            },
+            "end": {
+              "line": 22,
+              "column": 19186
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_altChanged\""
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "_altChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19188
+            },
+            "end": {
+              "line": 22,
+              "column": 19295
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 18986
+        },
+        "end": {
+          "line": 22,
+          "column": 19296
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "src",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19109
+            },
+            "end": {
+              "line": 22,
+              "column": 19126
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "icon",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19127
+            },
+            "end": {
+              "line": 22,
+              "column": 19145
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "alt",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 19146
+            },
+            "end": {
+              "line": 22,
+              "column": 19186
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-icon-button"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 23274
+        },
+        "end": {
+          "line": 22,
+          "column": 23329
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 22,
+              "column": 23234
+            },
+            "end": {
+              "line": 22,
+              "column": 23247
+            }
+          }
+        }
+      ],
+      "tagname": "paper-item"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "src",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24591
+            },
+            "end": {
+              "line": 22,
+              "column": 24617
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "alt",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24618
+            },
+            "end": {
+              "line": 22,
+              "column": 24646
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "crossorigin",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24647
+            },
+            "end": {
+              "line": 22,
+              "column": 24683
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "preventLoad",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24684
+            },
+            "end": {
+              "line": 22,
+              "column": 24719
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "sizing",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24720
+            },
+            "end": {
+              "line": 22,
+              "column": 24773
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "position",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24774
+            },
+            "end": {
+              "line": 22,
+              "column": 24811
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"center\""
+        },
+        {
+          "name": "preload",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24812
+            },
+            "end": {
+              "line": 22,
+              "column": 24843
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24844
+            },
+            "end": {
+              "line": 22,
+              "column": 24911
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_placeholderChanged\""
+            }
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "fade",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24912
+            },
+            "end": {
+              "line": 22,
+              "column": 24940
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "loaded",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24941
+            },
+            "end": {
+              "line": 22,
+              "column": 24993
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "loading",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24994
+            },
+            "end": {
+              "line": 22,
+              "column": 25047
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "error",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25048
+            },
+            "end": {
+              "line": 22,
+              "column": 25099
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "width",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25100
+            },
+            "end": {
+              "line": 22,
+              "column": 25155
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_widthChanged\""
+            }
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "height",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25156
+            },
+            "end": {
+              "line": 22,
+              "column": 25213
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_heightChanged\""
+            }
+          },
+          "defaultValue": "null"
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25304
+            },
+            "end": {
+              "line": 22,
+              "column": 25344
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_imgOnLoad",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25345
+            },
+            "end": {
+              "line": 22,
+              "column": 25474
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_imgOnError",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25475
+            },
+            "end": {
+              "line": 22,
+              "column": 25683
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computePlaceholderHidden",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25684
+            },
+            "end": {
+              "line": 22,
+              "column": 25781
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computePlaceholderClassName",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25782
+            },
+            "end": {
+              "line": 22,
+              "column": 25896
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computeImgDivHidden",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25897
+            },
+            "end": {
+              "line": 22,
+              "column": 25948
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computeImgDivARIAHidden",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25949
+            },
+            "end": {
+              "line": 22,
+              "column": 26019
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computeImgDivARIALabel",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 26020
+            },
+            "end": {
+              "line": 22,
+              "column": 26198
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computeImgHidden",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 26199
+            },
+            "end": {
+              "line": 22,
+              "column": 26248
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_widthChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 26249
+            },
+            "end": {
+              "line": 22,
+              "column": 26336
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_heightChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 26337
+            },
+            "end": {
+              "line": 22,
+              "column": 26429
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_loadStateObserver",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 26430
+            },
+            "end": {
+              "line": 22,
+              "column": 26872
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_placeholderChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 26873
+            },
+            "end": {
+              "line": 22,
+              "column": 26995
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_transformChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 26996
+            },
+            "end": {
+              "line": 22,
+              "column": 27265
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_resolveSrc",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 27266
+            },
+            "end": {
+              "line": 22,
+              "column": 27437
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 24562
+        },
+        "end": {
+          "line": 22,
+          "column": 27438
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "src",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24591
+            },
+            "end": {
+              "line": 22,
+              "column": 24617
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "alt",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24618
+            },
+            "end": {
+              "line": 22,
+              "column": 24646
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "crossorigin",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24647
+            },
+            "end": {
+              "line": 22,
+              "column": 24683
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "prevent-load",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24684
+            },
+            "end": {
+              "line": 22,
+              "column": 24719
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "sizing",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24720
+            },
+            "end": {
+              "line": 22,
+              "column": 24773
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "position",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24774
+            },
+            "end": {
+              "line": 22,
+              "column": 24811
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "preload",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24812
+            },
+            "end": {
+              "line": 22,
+              "column": 24843
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "placeholder",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24844
+            },
+            "end": {
+              "line": 22,
+              "column": 24911
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "fade",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24912
+            },
+            "end": {
+              "line": 22,
+              "column": 24940
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "loaded",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24941
+            },
+            "end": {
+              "line": 22,
+              "column": 24993
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "loading",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 24994
+            },
+            "end": {
+              "line": 22,
+              "column": 25047
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "error",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25048
+            },
+            "end": {
+              "line": 22,
+              "column": 25099
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "width",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25100
+            },
+            "end": {
+              "line": 22,
+              "column": 25155
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "height",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 25156
+            },
+            "end": {
+              "line": 22,
+              "column": 25213
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "loaded-changed",
+          "description": "Fired when the `loaded` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "loading-changed",
+          "description": "Fired when the `loading` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "error-changed",
+          "description": "Fired when the `error` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-image"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "name",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36148
+            },
+            "end": {
+              "line": 22,
+              "column": 36190
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_nameChanged\""
+            }
+          }
+        },
+        {
+          "name": "size",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36191
+            },
+            "end": {
+              "line": 22,
+              "column": 36218
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "24"
+        },
+        {
+          "name": "rtlMirroring",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36219
+            },
+            "end": {
+              "line": 22,
+              "column": 36255
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "useGlobalRtlAttribute",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36256
+            },
+            "end": {
+              "line": 22,
+              "column": 36301
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36303
+            },
+            "end": {
+              "line": 22,
+              "column": 36392
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36393
+            },
+            "end": {
+              "line": 22,
+              "column": 36439
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "getIconNames",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36440
+            },
+            "end": {
+              "line": 22,
+              "column": 36576
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "applyIcon",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36577
+            },
+            "end": {
+              "line": 22,
+              "column": 36786
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "removeIcon",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36787
+            },
+            "end": {
+              "line": 22,
+              "column": 36887
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_targetIsRTL",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36888
+            },
+            "end": {
+              "line": 22,
+              "column": 37259
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_nameChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 37260
+            },
+            "end": {
+              "line": 22,
+              "column": 37428
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_createIconMap",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 37429
+            },
+            "end": {
+              "line": 22,
+              "column": 37565
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_cloneIcon",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 37566
+            },
+            "end": {
+              "line": 22,
+              "column": 37695
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_prepareSvgClone",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 37696
+            },
+            "end": {
+              "line": 22,
+              "column": 38225
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 36113
+        },
+        "end": {
+          "line": 22,
+          "column": 38226
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "name",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36148
+            },
+            "end": {
+              "line": 22,
+              "column": 36190
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "size",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36191
+            },
+            "end": {
+              "line": 22,
+              "column": 36218
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "rtl-mirroring",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36219
+            },
+            "end": {
+              "line": 22,
+              "column": 36255
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "use-global-rtl-attribute",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 36256
+            },
+            "end": {
+              "line": 22,
+              "column": 36301
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-iconset-svg"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "mode",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 104838
+            },
+            "end": {
+              "line": 22,
+              "column": 104871
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"polite\""
+        },
+        {
+          "name": "_text",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 104872
+            },
+            "end": {
+              "line": 22,
+              "column": 104900
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 104902
+            },
+            "end": {
+              "line": 22,
+              "column": 105079
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "announce",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 105080
+            },
+            "end": {
+              "line": 22,
+              "column": 105156
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onIronAnnounce",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 105157
+            },
+            "end": {
+              "line": 22,
+              "column": 105239
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 104800
+        },
+        "end": {
+          "line": 22,
+          "column": 105240
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "name": "Polymer.IronA11yAnnouncer",
+      "attributes": [
+        {
+          "name": "mode",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 104838
+            },
+            "end": {
+              "line": 22,
+              "column": 104871
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-a11y-announcer"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "opened",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 113699
+            },
+            "end": {
+              "line": 22,
+              "column": 113777
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_openedChanged\""
+            }
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 113824
+            },
+            "end": {
+              "line": 22,
+              "column": 113865
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 113866
+            },
+            "end": {
+              "line": 22,
+              "column": 113932
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "prepare",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 113933
+            },
+            "end": {
+              "line": 22,
+              "column": 114028
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "open",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 114029
+            },
+            "end": {
+              "line": 22,
+              "column": 114060
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "close",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 114061
+            },
+            "end": {
+              "line": 22,
+              "column": 114093
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "complete",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 114094
+            },
+            "end": {
+              "line": 22,
+              "column": 114207
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onTransitionend",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 114208
+            },
+            "end": {
+              "line": 22,
+              "column": 114273
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_openedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 114274
+            },
+            "end": {
+              "line": 22,
+              "column": 114691
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 113659
+        },
+        "end": {
+          "line": 22,
+          "column": 114692
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "opened",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 113699
+            },
+            "end": {
+              "line": 22,
+              "column": 113777
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 22,
+              "column": 113581
+            },
+            "end": {
+              "line": 22,
+              "column": 113594
+            }
+          }
+        }
+      ],
+      "tagname": "iron-overlay-backdrop"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "fitInto",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132338
+            },
+            "end": {
+              "line": 22,
+              "column": 132401
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_onFitIntoChanged\""
+            }
+          }
+        },
+        {
+          "name": "horizontalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132402
+            },
+            "end": {
+              "line": 22,
+              "column": 132444
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"left\""
+        },
+        {
+          "name": "verticalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132445
+            },
+            "end": {
+              "line": 22,
+              "column": 132487
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"bottom\""
+        },
+        {
+          "name": "duration",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132488
+            },
+            "end": {
+              "line": 22,
+              "column": 132520
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "3000"
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132521
+            },
+            "end": {
+              "line": 22,
+              "column": 132548
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "noCancelOnOutsideClick",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132549
+            },
+            "end": {
+              "line": 22,
+              "column": 132595
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        },
+        {
+          "name": "noAutoFocus",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132596
+            },
+            "end": {
+              "line": 22,
+              "column": 132631
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        },
+        {
+          "name": "visible",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132679
+            },
+            "end": {
+              "line": 22,
+              "column": 132780
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_canAutoClose",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132781
+            },
+            "end": {
+              "line": 22,
+              "column": 132850
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132851
+            },
+            "end": {
+              "line": 22,
+              "column": 132939
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "show",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132940
+            },
+            "end": {
+              "line": 22,
+              "column": 133186
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "hide",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 133187
+            },
+            "end": {
+              "line": 22,
+              "column": 133216
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "__onTransitionEnd",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 133217
+            },
+            "end": {
+              "line": 22,
+              "column": 133363
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_openedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 133364
+            },
+            "end": {
+              "line": 22,
+              "column": 133722
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_renderOpened",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 133723
+            },
+            "end": {
+              "line": 22,
+              "column": 133787
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_renderClosed",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 133788
+            },
+            "end": {
+              "line": 22,
+              "column": 133855
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onFitIntoChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 133856
+            },
+            "end": {
+              "line": 22,
+              "column": 133908
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 22,
+          "column": 132268
+        },
+        "end": {
+          "line": 22,
+          "column": 133909
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "fit-into",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132338
+            },
+            "end": {
+              "line": 22,
+              "column": 132401
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "horizontal-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132402
+            },
+            "end": {
+              "line": 22,
+              "column": 132444
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "vertical-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132445
+            },
+            "end": {
+              "line": 22,
+              "column": 132487
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "duration",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132488
+            },
+            "end": {
+              "line": 22,
+              "column": 132520
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "text",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132521
+            },
+            "end": {
+              "line": 22,
+              "column": 132548
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "no-cancel-on-outside-click",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132549
+            },
+            "end": {
+              "line": 22,
+              "column": 132595
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-auto-focus",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 22,
+              "column": 132596
+            },
+            "end": {
+              "line": 22,
+              "column": 132631
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 22,
+              "column": 132192
+            },
+            "end": {
+              "line": 22,
+              "column": 132205
+            }
+          }
+        }
+      ],
+      "tagname": "paper-toast"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "raised",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 2711
+            },
+            "end": {
+              "line": 38,
+              "column": 2794
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_calculateElevation\""
+            }
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [
+        {
+          "name": "_calculateElevation",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 2796
+            },
+            "end": {
+              "line": 38,
+              "column": 2925
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 38,
+          "column": 2640
+        },
+        "end": {
+          "line": 38,
+          "column": 2926
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "raised",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 2711
+            },
+            "end": {
+              "line": 38,
+              "column": 2794
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 38,
+              "column": 2600
+            },
+            "end": {
+              "line": 38,
+              "column": 2613
+            }
+          }
+        }
+      ],
+      "tagname": "paper-button"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "bindValue",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4419
+            },
+            "end": {
+              "line": 38,
+              "column": 4442
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "value",
+          "type": "?",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4443
+            },
+            "end": {
+              "line": 38,
+              "column": 4486
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "allowedPattern",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4487
+            },
+            "end": {
+              "line": 38,
+              "column": 4515
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "autoValidate",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4516
+            },
+            "end": {
+              "line": 38,
+              "column": 4552
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_inputElement",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4553
+            },
+            "end": {
+              "line": 38,
+              "column": 4573
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "inputElement",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 5036
+            },
+            "end": {
+              "line": 38,
+              "column": 5081
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_patternRegExp",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 5277
+            },
+            "end": {
+              "line": 38,
+              "column": 5421
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4685
+            },
+            "end": {
+              "line": 38,
+              "column": 4811
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4812
+            },
+            "end": {
+              "line": 38,
+              "column": 4927
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4928
+            },
+            "end": {
+              "line": 38,
+              "column": 5035
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_initSlottedInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 5082
+            },
+            "end": {
+              "line": 38,
+              "column": 5276
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_bindValueChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 5422
+            },
+            "end": {
+              "line": 38,
+              "column": 5601
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_onInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 5602
+            },
+            "end": {
+              "line": 38,
+              "column": 5936
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_isPrintable",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 5937
+            },
+            "end": {
+              "line": 38,
+              "column": 6206
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onKeypress",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 6207
+            },
+            "end": {
+              "line": 38,
+              "column": 6541
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_checkPatternValidity",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 6542
+            },
+            "end": {
+              "line": 38,
+              "column": 6722
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "validate",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 6723
+            },
+            "end": {
+              "line": 38,
+              "column": 7026
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_announceInvalidCharacter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 7027
+            },
+            "end": {
+              "line": 38,
+              "column": 7101
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_computeValue",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 7102
+            },
+            "end": {
+              "line": 38,
+              "column": 7137
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 38,
+          "column": 4346
+        },
+        "end": {
+          "line": 38,
+          "column": 7138
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "bind-value",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4419
+            },
+            "end": {
+              "line": 38,
+              "column": 4442
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4443
+            },
+            "end": {
+              "line": 38,
+              "column": 4486
+            }
+          },
+          "metadata": {}
+        },
+        {
+          "name": "allowed-pattern",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4487
+            },
+            "end": {
+              "line": 38,
+              "column": 4515
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "auto-validate",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 4516
+            },
+            "end": {
+              "line": 38,
+              "column": 4552
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 38,
+              "column": 4293
+            },
+            "end": {
+              "line": 38,
+              "column": 4319
+            }
+          }
+        }
+      ],
+      "tagname": "iron-input"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "_charCounterStr",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 11257
+            },
+            "end": {
+              "line": 38,
+              "column": 11296
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"0\""
+        }
+      ],
+      "methods": [
+        {
+          "name": "update",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 38,
+              "column": 11298
+            },
+            "end": {
+              "line": 38,
+              "column": 11515
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 38,
+          "column": 11170
+        },
+        "end": {
+          "line": 38,
+          "column": 11516
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-input-char-counter"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "noLabelFloat",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1455
+            },
+            "end": {
+              "line": 54,
+              "column": 1491
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "alwaysFloatLabel",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1492
+            },
+            "end": {
+              "line": 54,
+              "column": 1532
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "attrForValue",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1533
+            },
+            "end": {
+              "line": 54,
+              "column": 1578
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"bind-value\""
+        },
+        {
+          "name": "autoValidate",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1579
+            },
+            "end": {
+              "line": 54,
+              "column": 1615
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "invalid",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1616
+            },
+            "end": {
+              "line": 54,
+              "column": 1674
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_invalidChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "focused",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1675
+            },
+            "end": {
+              "line": 54,
+              "column": 1728
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_addons",
+          "type": "Array",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1729
+            },
+            "end": {
+              "line": 54,
+              "column": 1749
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_inputHasContent",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1750
+            },
+            "end": {
+              "line": 54,
+              "column": 1790
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_inputSelector",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1791
+            },
+            "end": {
+              "line": 54,
+              "column": 1872
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"input,iron-input,textarea,.paper-input-input\""
+        },
+        {
+          "name": "_boundOnFocus",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1873
+            },
+            "end": {
+              "line": 54,
+              "column": 1952
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_boundOnBlur",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1953
+            },
+            "end": {
+              "line": 54,
+              "column": 2030
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_boundOnInput",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2031
+            },
+            "end": {
+              "line": 54,
+              "column": 2110
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_boundValueChanged",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2111
+            },
+            "end": {
+              "line": 54,
+              "column": 2202
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_valueChangedEvent",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2297
+            },
+            "end": {
+              "line": 54,
+              "column": 2358
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_propertyForValue",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2359
+            },
+            "end": {
+              "line": 54,
+              "column": 2441
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_inputElement",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2442
+            },
+            "end": {
+              "line": 54,
+              "column": 2522
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_inputElementValue",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2523
+            },
+            "end": {
+              "line": 54,
+              "column": 2624
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2625
+            },
+            "end": {
+              "line": 54,
+              "column": 2778
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 2779
+            },
+            "end": {
+              "line": 54,
+              "column": 3091
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onAddonAttached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3092
+            },
+            "end": {
+              "line": 54,
+              "column": 3276
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onFocus",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3277
+            },
+            "end": {
+              "line": 54,
+              "column": 3318
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onBlur",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3319
+            },
+            "end": {
+              "line": 54,
+              "column": 3412
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onInput",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3413
+            },
+            "end": {
+              "line": 54,
+              "column": 3477
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onValueChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3478
+            },
+            "end": {
+              "line": 54,
+              "column": 3582
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_handleValue",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3583
+            },
+            "end": {
+              "line": 54,
+              "column": 3773
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_handleValueAndAutoValidate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3774
+            },
+            "end": {
+              "line": 54,
+              "column": 3949
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onIronInputValidate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 3950
+            },
+            "end": {
+              "line": 54,
+              "column": 4022
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_invalidChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 4023
+            },
+            "end": {
+              "line": 54,
+              "column": 4106
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "updateAddons",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 4107
+            },
+            "end": {
+              "line": 54,
+              "column": 4180
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_computeInputContentClass",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 4181
+            },
+            "end": {
+              "line": 54,
+              "column": 4593
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            },
+            {
+              "name": "d"
+            },
+            {
+              "name": "e"
+            }
+          ]
+        },
+        {
+          "name": "_computeUnderlineClass",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 4594
+            },
+            "end": {
+              "line": 54,
+              "column": 4703
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_computeAddOnContentClass",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 4704
+            },
+            "end": {
+              "line": 54,
+              "column": 4821
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 54,
+          "column": 1415
+        },
+        "end": {
+          "line": 54,
+          "column": 4822
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "no-label-float",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1455
+            },
+            "end": {
+              "line": 54,
+              "column": 1491
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "always-float-label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1492
+            },
+            "end": {
+              "line": 54,
+              "column": 1532
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "attr-for-value",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1533
+            },
+            "end": {
+              "line": 54,
+              "column": 1578
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "auto-validate",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1579
+            },
+            "end": {
+              "line": 54,
+              "column": 1615
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "invalid",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1616
+            },
+            "end": {
+              "line": 54,
+              "column": 1674
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "focused",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 1675
+            },
+            "end": {
+              "line": 54,
+              "column": 1728
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "focused-changed",
+          "description": "Fired when the `focused` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "prefix",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 54,
+              "column": 862
+            },
+            "end": {
+              "line": 54,
+              "column": 889
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "label",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 54,
+              "column": 1032
+            },
+            "end": {
+              "line": 54,
+              "column": 1058
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "input",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 54,
+              "column": 1058
+            },
+            "end": {
+              "line": 54,
+              "column": 1084
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "suffix",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 54,
+              "column": 1111
+            },
+            "end": {
+              "line": 54,
+              "column": 1138
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "add-on",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 54,
+              "column": 1342
+            },
+            "end": {
+              "line": 54,
+              "column": 1369
+            }
+          }
+        }
+      ],
+      "tagname": "paper-input-container"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "invalid",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 5311
+            },
+            "end": {
+              "line": 54,
+              "column": 5367
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "update",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 5369
+            },
+            "end": {
+              "line": 54,
+              "column": 5416
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 54,
+          "column": 5231
+        },
+        "end": {
+          "line": 54,
+          "column": 5417
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "invalid",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 54,
+              "column": 5311
+            },
+            "end": {
+              "line": 54,
+              "column": 5367
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 54,
+              "column": 5178
+            },
+            "end": {
+              "line": 54,
+              "column": 5191
+            }
+          }
+        }
+      ],
+      "tagname": "paper-input-error"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "_focusableElement",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 3757
+            },
+            "end": {
+              "line": 55,
+              "column": 3854
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "beforeRegister",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 3434
+            },
+            "end": {
+              "line": 55,
+              "column": 3756
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onIronInputReady",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 3906
+            },
+            "end": {
+              "line": 55,
+              "column": 4138
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 3345
+        },
+        "end": {
+          "line": 55,
+          "column": 4139
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "prefix",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 949
+            },
+            "end": {
+              "line": 55,
+              "column": 990
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "suffix",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 1118
+            },
+            "end": {
+              "line": 55,
+              "column": 1159
+            }
+          }
+        }
+      ],
+      "tagname": "paper-input"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4198
+            },
+            "end": {
+              "line": 55,
+              "column": 4224
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "xhr",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4237
+            },
+            "end": {
+              "line": 55,
+              "column": 4320
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "response",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4321
+            },
+            "end": {
+              "line": 55,
+              "column": 4395
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "status",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4396
+            },
+            "end": {
+              "line": 55,
+              "column": 4446
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "0"
+        },
+        {
+          "name": "statusText",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4447
+            },
+            "end": {
+              "line": 55,
+              "column": 4502
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "completes",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4503
+            },
+            "end": {
+              "line": 55,
+              "column": 4659
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "progress",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4660
+            },
+            "end": {
+              "line": 55,
+              "column": 4731
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "aborted",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4732
+            },
+            "end": {
+              "line": 55,
+              "column": 4785
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "errored",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4786
+            },
+            "end": {
+              "line": 55,
+              "column": 4839
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "timedOut",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4840
+            },
+            "end": {
+              "line": 55,
+              "column": 4894
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "succeeded",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4896
+            },
+            "end": {
+              "line": 55,
+              "column": 5019
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "send",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 5020
+            },
+            "end": {
+              "line": 55,
+              "column": 6896
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "parseResponse",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 6897
+            },
+            "end": {
+              "line": 55,
+              "column": 7585
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "abort",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 7586
+            },
+            "end": {
+              "line": 55,
+              "column": 7641
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_encodeBodyObject",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 7642
+            },
+            "end": {
+              "line": 55,
+              "column": 7828
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_wwwFormUrlEncode",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 7829
+            },
+            "end": {
+              "line": 55,
+              "column": 8021
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_wwwFormUrlEncodePiece",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8022
+            },
+            "end": {
+              "line": 55,
+              "column": 8178
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_updateStatus",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8179
+            },
+            "end": {
+              "line": 55,
+              "column": 8310
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 4179
+        },
+        "end": {
+          "line": 55,
+          "column": 8311
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "xhr",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4237
+            },
+            "end": {
+              "line": 55,
+              "column": 4320
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "response",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4321
+            },
+            "end": {
+              "line": 55,
+              "column": 4395
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "status",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4396
+            },
+            "end": {
+              "line": 55,
+              "column": 4446
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "status-text",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4447
+            },
+            "end": {
+              "line": 55,
+              "column": 4502
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "completes",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4503
+            },
+            "end": {
+              "line": 55,
+              "column": 4659
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "progress",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4660
+            },
+            "end": {
+              "line": 55,
+              "column": 4731
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "aborted",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4732
+            },
+            "end": {
+              "line": 55,
+              "column": 4785
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "errored",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4786
+            },
+            "end": {
+              "line": 55,
+              "column": 4839
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "timed-out",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 4840
+            },
+            "end": {
+              "line": 55,
+              "column": 4894
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "xhr-changed",
+          "description": "Fired when the `xhr` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "response-changed",
+          "description": "Fired when the `response` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "status-changed",
+          "description": "Fired when the `status` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "status-text-changed",
+          "description": "Fired when the `statusText` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "completes-changed",
+          "description": "Fired when the `completes` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "progress-changed",
+          "description": "Fired when the `progress` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "aborted-changed",
+          "description": "Fired when the `aborted` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "errored-changed",
+          "description": "Fired when the `errored` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "timed-out-changed",
+          "description": "Fired when the `timedOut` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-request"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8367
+            },
+            "end": {
+              "line": 55,
+              "column": 8393
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "url",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8406
+            },
+            "end": {
+              "line": 55,
+              "column": 8423
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "params",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8424
+            },
+            "end": {
+              "line": 55,
+              "column": 8471
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "method",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8472
+            },
+            "end": {
+              "line": 55,
+              "column": 8504
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"GET\""
+        },
+        {
+          "name": "headers",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8505
+            },
+            "end": {
+              "line": 55,
+              "column": 8553
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "contentType",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8554
+            },
+            "end": {
+              "line": 55,
+              "column": 8590
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "body",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8591
+            },
+            "end": {
+              "line": 55,
+              "column": 8620
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "null"
+        },
+        {
+          "name": "sync",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8621
+            },
+            "end": {
+              "line": 55,
+              "column": 8649
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "handleAs",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8650
+            },
+            "end": {
+              "line": 55,
+              "column": 8685
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"json\""
+        },
+        {
+          "name": "withCredentials",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8686
+            },
+            "end": {
+              "line": 55,
+              "column": 8725
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "timeout",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8726
+            },
+            "end": {
+              "line": 55,
+              "column": 8755
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "0"
+        },
+        {
+          "name": "auto",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8756
+            },
+            "end": {
+              "line": 55,
+              "column": 8784
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "verbose",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8785
+            },
+            "end": {
+              "line": 55,
+              "column": 8816
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "lastRequest",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8817
+            },
+            "end": {
+              "line": 55,
+              "column": 8864
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "lastProgress",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8865
+            },
+            "end": {
+              "line": 55,
+              "column": 8913
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "loading",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8914
+            },
+            "end": {
+              "line": 55,
+              "column": 8958
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "lastResponse",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8959
+            },
+            "end": {
+              "line": 55,
+              "column": 9007
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "lastError",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9008
+            },
+            "end": {
+              "line": 55,
+              "column": 9053
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "activeRequests",
+          "type": "Array",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9054
+            },
+            "end": {
+              "line": 55,
+              "column": 9130
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "debounceDuration",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9131
+            },
+            "end": {
+              "line": 55,
+              "column": 9179
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "0"
+        },
+        {
+          "name": "jsonPrefix",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9180
+            },
+            "end": {
+              "line": 55,
+              "column": 9213
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "bubbles",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9214
+            },
+            "end": {
+              "line": 55,
+              "column": 9245
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "rejectWithRequest",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9246
+            },
+            "end": {
+              "line": 55,
+              "column": 9287
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_boundHandleResponse",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9288
+            },
+            "end": {
+              "line": 55,
+              "column": 9381
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "queryString",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9615
+            },
+            "end": {
+              "line": 55,
+              "column": 9894
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "requestUrl",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9895
+            },
+            "end": {
+              "line": 55,
+              "column": 10010
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "requestHeaders",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 10011
+            },
+            "end": {
+              "line": 55,
+              "column": 10278
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "created",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9531
+            },
+            "end": {
+              "line": 55,
+              "column": 9614
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onProgressChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 10279
+            },
+            "end": {
+              "line": 55,
+              "column": 10348
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "toRequestOptions",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 10349
+            },
+            "end": {
+              "line": 55,
+              "column": 10637
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "generateRequest",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 10638
+            },
+            "end": {
+              "line": 55,
+              "column": 11496
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_handleResponse",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 11497
+            },
+            "end": {
+              "line": 55,
+              "column": 11757
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_handleError",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 11758
+            },
+            "end": {
+              "line": 55,
+              "column": 12165
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_discardRequest",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12166
+            },
+            "end": {
+              "line": 55,
+              "column": 12271
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_requestOptionsChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12272
+            },
+            "end": {
+              "line": 55,
+              "column": 12424
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 8351
+        },
+        "end": {
+          "line": 55,
+          "column": 12425
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "url",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8406
+            },
+            "end": {
+              "line": 55,
+              "column": 8423
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "params",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8424
+            },
+            "end": {
+              "line": 55,
+              "column": 8471
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "method",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8472
+            },
+            "end": {
+              "line": 55,
+              "column": 8504
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "headers",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8505
+            },
+            "end": {
+              "line": 55,
+              "column": 8553
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "content-type",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8554
+            },
+            "end": {
+              "line": 55,
+              "column": 8590
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "body",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8591
+            },
+            "end": {
+              "line": 55,
+              "column": 8620
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "sync",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8621
+            },
+            "end": {
+              "line": 55,
+              "column": 8649
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "handle-as",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8650
+            },
+            "end": {
+              "line": 55,
+              "column": 8685
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "with-credentials",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8686
+            },
+            "end": {
+              "line": 55,
+              "column": 8725
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "timeout",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8726
+            },
+            "end": {
+              "line": 55,
+              "column": 8755
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "auto",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8756
+            },
+            "end": {
+              "line": 55,
+              "column": 8784
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "verbose",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8785
+            },
+            "end": {
+              "line": 55,
+              "column": 8816
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "last-request",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8817
+            },
+            "end": {
+              "line": 55,
+              "column": 8864
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "last-progress",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8865
+            },
+            "end": {
+              "line": 55,
+              "column": 8913
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "loading",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8914
+            },
+            "end": {
+              "line": 55,
+              "column": 8958
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "last-response",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 8959
+            },
+            "end": {
+              "line": 55,
+              "column": 9007
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "last-error",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9008
+            },
+            "end": {
+              "line": 55,
+              "column": 9053
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "active-requests",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9054
+            },
+            "end": {
+              "line": 55,
+              "column": 9130
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "debounce-duration",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9131
+            },
+            "end": {
+              "line": 55,
+              "column": 9179
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "json-prefix",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9180
+            },
+            "end": {
+              "line": 55,
+              "column": 9213
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "bubbles",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9214
+            },
+            "end": {
+              "line": 55,
+              "column": 9245
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "reject-with-request",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 9246
+            },
+            "end": {
+              "line": 55,
+              "column": 9287
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "last-request-changed",
+          "description": "Fired when the `lastRequest` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "last-progress-changed",
+          "description": "Fired when the `lastProgress` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "loading-changed",
+          "description": "Fired when the `loading` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "last-response-changed",
+          "description": "Fired when the `lastResponse` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "last-error-changed",
+          "description": "Fired when the `lastError` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "active-requests-changed",
+          "description": "Fired when the `activeRequests` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "debounce-duration-changed",
+          "description": "Fired when the `debounceDuration` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "iron-ajax"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "allowRedirect",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12710
+            },
+            "end": {
+              "line": 55,
+              "column": 12747
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "headers",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12748
+            },
+            "end": {
+              "line": 55,
+              "column": 12796
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "withCredentials",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12797
+            },
+            "end": {
+              "line": 55,
+              "column": 12836
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12838
+            },
+            "end": {
+              "line": 55,
+              "column": 13099
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 13100
+            },
+            "end": {
+              "line": 55,
+              "column": 13219
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_init",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 13220
+            },
+            "end": {
+              "line": 55,
+              "column": 13548
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "validate",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 13549
+            },
+            "end": {
+              "line": 55,
+              "column": 13771
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "submit",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 13772
+            },
+            "end": {
+              "line": 55,
+              "column": 14347
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "reset",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 14348
+            },
+            "end": {
+              "line": 55,
+              "column": 14564
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "serializeForm",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 14565
+            },
+            "end": {
+              "line": 55,
+              "column": 14776
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_handleFormResponse",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 14777
+            },
+            "end": {
+              "line": 55,
+              "column": 14850
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_handleFormError",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 14851
+            },
+            "end": {
+              "line": 55,
+              "column": 14918
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_makeAjaxRequest",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 14919
+            },
+            "end": {
+              "line": 55,
+              "column": 15682
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_getValidatableElements",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 15683
+            },
+            "end": {
+              "line": 55,
+              "column": 15759
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getSubmittableElements",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 15760
+            },
+            "end": {
+              "line": 55,
+              "column": 15836
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_findElements",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 15837
+            },
+            "end": {
+              "line": 55,
+              "column": 16056
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_serializeElementValues",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 16057
+            },
+            "end": {
+              "line": 55,
+              "column": 16341
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_serializeSelectValues",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 16342
+            },
+            "end": {
+              "line": 55,
+              "column": 16476
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_serializeInputValues",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 16477
+            },
+            "end": {
+              "line": 55,
+              "column": 16610
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_createHiddenElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 16611
+            },
+            "end": {
+              "line": 55,
+              "column": 16776
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_addSerializedElement",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 16777
+            },
+            "end": {
+              "line": 55,
+              "column": 16887
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            },
+            {
+              "name": "c"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 12682
+        },
+        "end": {
+          "line": 55,
+          "column": 16888
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "allow-redirect",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12710
+            },
+            "end": {
+              "line": 55,
+              "column": 12747
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "headers",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12748
+            },
+            "end": {
+              "line": 55,
+              "column": 12796
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "with-credentials",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 12797
+            },
+            "end": {
+              "line": 55,
+              "column": 12836
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 12552
+            },
+            "end": {
+              "line": 55,
+              "column": 12565
+            }
+          }
+        }
+      ],
+      "tagname": "iron-form"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "horizontalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20541
+            },
+            "end": {
+              "line": 55,
+              "column": 20605
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"left\""
+        },
+        {
+          "name": "verticalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20606
+            },
+            "end": {
+              "line": 55,
+              "column": 20667
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"top\""
+        },
+        {
+          "name": "openAnimationConfig",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20668
+            },
+            "end": {
+              "line": 55,
+              "column": 20701
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "closeAnimationConfig",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20702
+            },
+            "end": {
+              "line": 55,
+              "column": 20736
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "focusTarget",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20737
+            },
+            "end": {
+              "line": 55,
+              "column": 20762
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "noAnimations",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20763
+            },
+            "end": {
+              "line": 55,
+              "column": 20799
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "allowOutsideScroll",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20800
+            },
+            "end": {
+              "line": 55,
+              "column": 20880
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_allowOutsideScrollChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "containedElement",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 21062
+            },
+            "end": {
+              "line": 55,
+              "column": 21217
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 21218
+            },
+            "end": {
+              "line": 55,
+              "column": 21330
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 21331
+            },
+            "end": {
+              "line": 55,
+              "column": 21444
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 21445
+            },
+            "end": {
+              "line": 55,
+              "column": 21488
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_openedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 21489
+            },
+            "end": {
+              "line": 55,
+              "column": 21680
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_renderOpened",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 21681
+            },
+            "end": {
+              "line": 55,
+              "column": 21898
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_renderClosed",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 21899
+            },
+            "end": {
+              "line": 55,
+              "column": 22118
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onNeonAnimationFinish",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 22119
+            },
+            "end": {
+              "line": 55,
+              "column": 22271
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_updateAnimationConfig",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 22272
+            },
+            "end": {
+              "line": 55,
+              "column": 22534
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_updateOverlayPosition",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 22535
+            },
+            "end": {
+              "line": 55,
+              "column": 22606
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_allowOutsideScrollChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 22607
+            },
+            "end": {
+              "line": 55,
+              "column": 22768
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_applyFocus",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 22769
+            },
+            "end": {
+              "line": 55,
+              "column": 22948
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 20379
+        },
+        "end": {
+          "line": 55,
+          "column": 22949
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "horizontal-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20541
+            },
+            "end": {
+              "line": 55,
+              "column": 20605
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "vertical-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20606
+            },
+            "end": {
+              "line": 55,
+              "column": 20667
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "open-animation-config",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20668
+            },
+            "end": {
+              "line": 55,
+              "column": 20701
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "close-animation-config",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20702
+            },
+            "end": {
+              "line": 55,
+              "column": 20736
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "focus-target",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20737
+            },
+            "end": {
+              "line": 55,
+              "column": 20762
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "no-animations",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20763
+            },
+            "end": {
+              "line": 55,
+              "column": 20799
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "allow-outside-scroll",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 20800
+            },
+            "end": {
+              "line": 55,
+              "column": 20880
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "dropdown-content",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 20271
+            },
+            "end": {
+              "line": 55,
+              "column": 20321
+            }
+          }
+        }
+      ],
+      "tagname": "iron-dropdown"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "configure",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 23754
+            },
+            "end": {
+              "line": 55,
+              "column": 23899
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 23688
+        },
+        "end": {
+          "line": 55,
+          "column": 23900
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "fade-in-animation"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "configure",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 23994
+            },
+            "end": {
+              "line": 55,
+              "column": 24139
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 23927
+        },
+        "end": {
+          "line": 55,
+          "column": 24140
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "fade-out-animation"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "configure",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 24248
+            },
+            "end": {
+              "line": 55,
+              "column": 24438
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 24167
+        },
+        "end": {
+          "line": 55,
+          "column": 24439
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-menu-grow-height-animation"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "configure",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 24529
+            },
+            "end": {
+              "line": 55,
+              "column": 24716
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 24449
+        },
+        "end": {
+          "line": 55,
+          "column": 24717
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-menu-grow-width-animation"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "configure",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 24809
+            },
+            "end": {
+              "line": 55,
+              "column": 24999
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 24727
+        },
+        "end": {
+          "line": 55,
+          "column": 25000
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-menu-shrink-width-animation"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "configure",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 25093
+            },
+            "end": {
+              "line": 55,
+              "column": 25399
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 25010
+        },
+        "end": {
+          "line": 55,
+          "column": 25400
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-menu-shrink-height-animation"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "opened",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27223
+            },
+            "end": {
+              "line": 55,
+              "column": 27289
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_openedChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "horizontalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27290
+            },
+            "end": {
+              "line": 55,
+              "column": 27354
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"left\""
+        },
+        {
+          "name": "verticalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27355
+            },
+            "end": {
+              "line": 55,
+              "column": 27416
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"top\""
+        },
+        {
+          "name": "dynamicAlign",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27417
+            },
+            "end": {
+              "line": 55,
+              "column": 27444
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "horizontalOffset",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27445
+            },
+            "end": {
+              "line": 55,
+              "column": 27493
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "0"
+        },
+        {
+          "name": "verticalOffset",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27494
+            },
+            "end": {
+              "line": 55,
+              "column": 27540
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "0"
+        },
+        {
+          "name": "noOverlap",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27541
+            },
+            "end": {
+              "line": 55,
+              "column": 27565
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "noAnimations",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27566
+            },
+            "end": {
+              "line": 55,
+              "column": 27602
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "ignoreSelect",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27603
+            },
+            "end": {
+              "line": 55,
+              "column": 27639
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "closeOnActivate",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27640
+            },
+            "end": {
+              "line": 55,
+              "column": 27679
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "openAnimationConfig",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27680
+            },
+            "end": {
+              "line": 55,
+              "column": 28009
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "closeAnimationConfig",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28010
+            },
+            "end": {
+              "line": 55,
+              "column": 28309
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
+        },
+        {
+          "name": "allowOutsideScroll",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28310
+            },
+            "end": {
+              "line": 55,
+              "column": 28352
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "restoreFocusOnClose",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28353
+            },
+            "end": {
+              "line": 55,
+              "column": 28396
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        },
+        {
+          "name": "_dropdownContent",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28397
+            },
+            "end": {
+              "line": 55,
+              "column": 28427
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28429
+            },
+            "end": {
+              "line": 55,
+              "column": 28481
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "contentElement",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28558
+            },
+            "end": {
+              "line": 55,
+              "column": 28711
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "toggle",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28712
+            },
+            "end": {
+              "line": 55,
+              "column": 28767
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "open",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28768
+            },
+            "end": {
+              "line": 55,
+              "column": 28822
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "close",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28823
+            },
+            "end": {
+              "line": 55,
+              "column": 28864
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onIronSelect",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28865
+            },
+            "end": {
+              "line": 55,
+              "column": 28922
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onIronActivate",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28923
+            },
+            "end": {
+              "line": 55,
+              "column": 28985
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_openedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28986
+            },
+            "end": {
+              "line": 55,
+              "column": 29137
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_disabledChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 29138
+            },
+            "end": {
+              "line": 55,
+              "column": 29260
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "__onIronOverlayCanceled",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 29261
+            },
+            "end": {
+              "line": 55,
+              "column": 29415
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 27121
+        },
+        "end": {
+          "line": 55,
+          "column": 29416
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "name": "b",
+      "attributes": [
+        {
+          "name": "opened",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27223
+            },
+            "end": {
+              "line": 55,
+              "column": 27289
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "horizontal-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27290
+            },
+            "end": {
+              "line": 55,
+              "column": 27354
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "vertical-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27355
+            },
+            "end": {
+              "line": 55,
+              "column": 27416
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "dynamic-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27417
+            },
+            "end": {
+              "line": 55,
+              "column": 27444
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "horizontal-offset",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27445
+            },
+            "end": {
+              "line": 55,
+              "column": 27493
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "vertical-offset",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27494
+            },
+            "end": {
+              "line": 55,
+              "column": 27540
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "no-overlap",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27541
+            },
+            "end": {
+              "line": 55,
+              "column": 27565
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-animations",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27566
+            },
+            "end": {
+              "line": 55,
+              "column": 27602
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "ignore-select",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27603
+            },
+            "end": {
+              "line": 55,
+              "column": 27639
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "close-on-activate",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27640
+            },
+            "end": {
+              "line": 55,
+              "column": 27679
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "open-animation-config",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 27680
+            },
+            "end": {
+              "line": 55,
+              "column": 28009
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "close-animation-config",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28010
+            },
+            "end": {
+              "line": 55,
+              "column": 28309
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "allow-outside-scroll",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28310
+            },
+            "end": {
+              "line": 55,
+              "column": 28352
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "restore-focus-on-close",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 28353
+            },
+            "end": {
+              "line": 55,
+              "column": 28396
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "opened-changed",
+          "description": "Fired when the `opened` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "horizontal-offset-changed",
+          "description": "Fired when the `horizontalOffset` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "vertical-offset-changed",
+          "description": "Fired when the `verticalOffset` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "dropdown-trigger",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 26239
+            },
+            "end": {
+              "line": 55,
+              "column": 26276
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "dropdown-content",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 26910
+            },
+            "end": {
+              "line": 55,
+              "column": 26960
+            }
+          }
+        }
+      ],
+      "tagname": "paper-menu-button"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "selectedItemLabel",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32005
+            },
+            "end": {
+              "line": 55,
+              "column": 32058
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "selectedItem",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32059
+            },
+            "end": {
+              "line": 55,
+              "column": 32107
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "value",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32108
+            },
+            "end": {
+              "line": 55,
+              "column": 32149
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32150
+            },
+            "end": {
+              "line": 55,
+              "column": 32169
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32170
+            },
+            "end": {
+              "line": 55,
+              "column": 32195
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "errorMessage",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32196
+            },
+            "end": {
+              "line": 55,
+              "column": 32222
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "opened",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32223
+            },
+            "end": {
+              "line": 55,
+              "column": 32289
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_openedChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "allowOutsideScroll",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32290
+            },
+            "end": {
+              "line": 55,
+              "column": 32332
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "noLabelFloat",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32333
+            },
+            "end": {
+              "line": 55,
+              "column": 32391
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "alwaysFloatLabel",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32392
+            },
+            "end": {
+              "line": 55,
+              "column": 32432
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "noAnimations",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32433
+            },
+            "end": {
+              "line": 55,
+              "column": 32469
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "horizontalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32470
+            },
+            "end": {
+              "line": 55,
+              "column": 32513
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"right\""
+        },
+        {
+          "name": "verticalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32514
+            },
+            "end": {
+              "line": 55,
+              "column": 32553
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"top\""
+        },
+        {
+          "name": "dynamicAlign",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32554
+            },
+            "end": {
+              "line": 55,
+              "column": 32581
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "restoreFocusOnClose",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32582
+            },
+            "end": {
+              "line": 55,
+              "column": 32625
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        },
+        {
+          "name": "keyBindings",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32652
+            },
+            "end": {
+              "line": 55,
+              "column": 32694
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32695
+            },
+            "end": {
+              "line": 55,
+              "column": 32777
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "contentElement",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32931
+            },
+            "end": {
+              "line": 55,
+              "column": 33084
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32827
+            },
+            "end": {
+              "line": 55,
+              "column": 32930
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "open",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33085
+            },
+            "end": {
+              "line": 55,
+              "column": 33126
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "close",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33127
+            },
+            "end": {
+              "line": 55,
+              "column": 33170
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onIronSelect",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33171
+            },
+            "end": {
+              "line": 55,
+              "column": 33234
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onIronDeselect",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33235
+            },
+            "end": {
+              "line": 55,
+              "column": 33290
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onTap",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33291
+            },
+            "end": {
+              "line": 55,
+              "column": 33369
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_selectedItemChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33370
+            },
+            "end": {
+              "line": 55,
+              "column": 33522
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_computeMenuVerticalOffset",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33523
+            },
+            "end": {
+              "line": 55,
+              "column": 33576
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_getValidity",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33577
+            },
+            "end": {
+              "line": 55,
+              "column": 33667
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_openedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 33668
+            },
+            "end": {
+              "line": 55,
+              "column": 33786
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 31842
+        },
+        "end": {
+          "line": 55,
+          "column": 33787
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "selected-item-label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32005
+            },
+            "end": {
+              "line": 55,
+              "column": 32058
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "selected-item",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32059
+            },
+            "end": {
+              "line": 55,
+              "column": 32107
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "value",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32108
+            },
+            "end": {
+              "line": 55,
+              "column": 32149
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32150
+            },
+            "end": {
+              "line": 55,
+              "column": 32169
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "placeholder",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32170
+            },
+            "end": {
+              "line": 55,
+              "column": 32195
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "error-message",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32196
+            },
+            "end": {
+              "line": 55,
+              "column": 32222
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "opened",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32223
+            },
+            "end": {
+              "line": 55,
+              "column": 32289
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "allow-outside-scroll",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32290
+            },
+            "end": {
+              "line": 55,
+              "column": 32332
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-label-float",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32333
+            },
+            "end": {
+              "line": 55,
+              "column": 32391
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "always-float-label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32392
+            },
+            "end": {
+              "line": 55,
+              "column": 32432
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-animations",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32433
+            },
+            "end": {
+              "line": 55,
+              "column": 32469
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "horizontal-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32470
+            },
+            "end": {
+              "line": 55,
+              "column": 32513
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "vertical-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32514
+            },
+            "end": {
+              "line": 55,
+              "column": 32553
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "dynamic-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32554
+            },
+            "end": {
+              "line": 55,
+              "column": 32581
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "restore-focus-on-close",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 32582
+            },
+            "end": {
+              "line": 55,
+              "column": 32625
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "selected-item-label-changed",
+          "description": "Fired when the `selectedItemLabel` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "selected-item-changed",
+          "description": "Fired when the `selectedItem` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "value-changed",
+          "description": "Fired when the `value` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "opened-changed",
+          "description": "Fired when the `opened` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "dropdown-content",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 31696
+            },
+            "end": {
+              "line": 55,
+              "column": 31770
+            }
+          }
+        }
+      ],
+      "tagname": "paper-dropdown-menu"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 38669
+            },
+            "end": {
+              "line": 55,
+              "column": 38700
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 38612
+        },
+        "end": {
+          "line": 55,
+          "column": 38701
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 38560
+            },
+            "end": {
+              "line": 55,
+              "column": 38573
+            }
+          }
+        }
+      ],
+      "tagname": "paper-listbox"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "label",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41601
+            },
+            "end": {
+              "line": 55,
+              "column": 41620
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "disabled",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41621
+            },
+            "end": {
+              "line": 55,
+              "column": 41653
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "value",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41654
+            },
+            "end": {
+              "line": 55,
+              "column": 41710
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_updateSelected\""
+            }
+          }
+        },
+        {
+          "name": "selected",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41711
+            },
+            "end": {
+              "line": 55,
+              "column": 41767
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_updateValue\""
+            }
+          }
+        },
+        {
+          "name": "opened",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41768
+            },
+            "end": {
+              "line": 55,
+              "column": 41836
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_onOpenedChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "searchable",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41837
+            },
+            "end": {
+              "line": 55,
+              "column": 41871
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "errorMessage",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41872
+            },
+            "end": {
+              "line": 55,
+              "column": 41898
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "allowOutsideScroll",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41899
+            },
+            "end": {
+              "line": 55,
+              "column": 41941
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "noLabelFloat",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41942
+            },
+            "end": {
+              "line": 55,
+              "column": 42000
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "alwaysFloatLabel",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42001
+            },
+            "end": {
+              "line": 55,
+              "column": 42041
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "noAnimations",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42042
+            },
+            "end": {
+              "line": 55,
+              "column": 42078
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "horizontalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42079
+            },
+            "end": {
+              "line": 55,
+              "column": 42122
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"right\""
+        },
+        {
+          "name": "verticalAlign",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42123
+            },
+            "end": {
+              "line": 55,
+              "column": 42162
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"top\""
+        },
+        {
+          "name": "dynamicAlign",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42163
+            },
+            "end": {
+              "line": 55,
+              "column": 42190
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "restoreFocusOnClose",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42191
+            },
+            "end": {
+              "line": 55,
+              "column": 42234
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "true"
+        },
+        {
+          "name": "multi",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42235
+            },
+            "end": {
+              "line": 55,
+              "column": 42289
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_multiChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "UP_KEY_CODE",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42548
+            },
+            "end": {
+              "line": 55,
+              "column": 42562
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "DOWN_KEY_CODE",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42563
+            },
+            "end": {
+              "line": 55,
+              "column": 42579
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42580
+            },
+            "end": {
+              "line": 55,
+              "column": 42658
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "open",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42659
+            },
+            "end": {
+              "line": 55,
+              "column": 42702
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "close",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42703
+            },
+            "end": {
+              "line": 55,
+              "column": 42748
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_multiChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42749
+            },
+            "end": {
+              "line": 55,
+              "column": 43011
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_selectedItemsChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 43012
+            },
+            "end": {
+              "line": 55,
+              "column": 43225
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_updateSelectedItemLabel",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 43226
+            },
+            "end": {
+              "line": 55,
+              "column": 43556
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getItemValue",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 43557
+            },
+            "end": {
+              "line": 55,
+              "column": 43664
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_itemsChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 43665
+            },
+            "end": {
+              "line": 55,
+              "column": 43882
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_getItemValueFromItems",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 43883
+            },
+            "end": {
+              "line": 55,
+              "column": 43952
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_getItemLabel",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 43953
+            },
+            "end": {
+              "line": 55,
+              "column": 44007
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_getItemLabelFromItems",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 44008
+            },
+            "end": {
+              "line": 55,
+              "column": 44077
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_updateSelected",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 44078
+            },
+            "end": {
+              "line": 55,
+              "column": 44374
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_updateValue",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 44375
+            },
+            "end": {
+              "line": 55,
+              "column": 44547
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onOpenedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 44548
+            },
+            "end": {
+              "line": 55,
+              "column": 44645
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_stopEventPropagation",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 44646
+            },
+            "end": {
+              "line": 55,
+              "column": 44760
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_filter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 44761
+            },
+            "end": {
+              "line": 55,
+              "column": 44891
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 41568
+        },
+        "end": {
+          "line": 55,
+          "column": 44892
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41601
+            },
+            "end": {
+              "line": 55,
+              "column": 41620
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "disabled",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41621
+            },
+            "end": {
+              "line": 55,
+              "column": 41653
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "value",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41654
+            },
+            "end": {
+              "line": 55,
+              "column": 41710
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "selected",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41711
+            },
+            "end": {
+              "line": 55,
+              "column": 41767
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "opened",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41768
+            },
+            "end": {
+              "line": 55,
+              "column": 41836
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "searchable",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41837
+            },
+            "end": {
+              "line": 55,
+              "column": 41871
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "error-message",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41872
+            },
+            "end": {
+              "line": 55,
+              "column": 41898
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "allow-outside-scroll",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41899
+            },
+            "end": {
+              "line": 55,
+              "column": 41941
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-label-float",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 41942
+            },
+            "end": {
+              "line": 55,
+              "column": 42000
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "always-float-label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42001
+            },
+            "end": {
+              "line": 55,
+              "column": 42041
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-animations",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42042
+            },
+            "end": {
+              "line": 55,
+              "column": 42078
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "horizontal-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42079
+            },
+            "end": {
+              "line": 55,
+              "column": 42122
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "vertical-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42123
+            },
+            "end": {
+              "line": 55,
+              "column": 42162
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "dynamic-align",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42163
+            },
+            "end": {
+              "line": 55,
+              "column": 42190
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "restore-focus-on-close",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42191
+            },
+            "end": {
+              "line": 55,
+              "column": 42234
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "multi",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 42235
+            },
+            "end": {
+              "line": 55,
+              "column": 42289
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "value-changed",
+          "description": "Fired when the `value` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "selected-changed",
+          "description": "Fired when the `selected` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "opened-changed",
+          "description": "Fired when the `opened` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 41490
+            },
+            "end": {
+              "line": 55,
+              "column": 41503
+            }
+          }
+        }
+      ],
+      "tagname": "paper-dropdown"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [
+        {
+          "name": "_renderOpened",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 57115
+            },
+            "end": {
+              "line": 55,
+              "column": 57191
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_renderClosed",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 57192
+            },
+            "end": {
+              "line": 55,
+              "column": 57267
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onNeonAnimationFinish",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 55,
+              "column": 57268
+            },
+            "end": {
+              "line": 55,
+              "column": 57368
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 55,
+          "column": 56959
+        },
+        "end": {
+          "line": 55,
+          "column": 57369
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 55,
+              "column": 56906
+            },
+            "end": {
+              "line": 55,
+              "column": 56919
+            }
+          }
+        }
+      ],
+      "tagname": "paper-dialog"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 48893
+            },
+            "end": {
+              "line": 76,
+              "column": 48954
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "ariaActiveAttribute",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 48967
+            },
+            "end": {
+              "line": 76,
+              "column": 49021
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"aria-checked\""
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 49023
+            },
+            "end": {
+              "line": 76,
+              "column": 49426
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computeCheckboxClass",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 49427
+            },
+            "end": {
+              "line": 76,
+              "column": 49518
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_computeCheckmarkClass",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 49519
+            },
+            "end": {
+              "line": 76,
+              "column": 49575
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_createRipple",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 49576
+            },
+            "end": {
+              "line": 76,
+              "column": 49715
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 76,
+          "column": 48824
+        },
+        "end": {
+          "line": 76,
+          "column": 49716
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "aria-active-attribute",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 48967
+            },
+            "end": {
+              "line": 76,
+              "column": 49021
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 76,
+              "column": 48778
+            },
+            "end": {
+              "line": 76,
+              "column": 48791
+            }
+          }
+        }
+      ],
+      "tagname": "paper-checkbox"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 76,
+          "column": 50393
+        },
+        "end": {
+          "line": 76,
+          "column": 50415
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 76,
+              "column": 50353
+            },
+            "end": {
+              "line": 76,
+              "column": 50366
+            }
+          }
+        }
+      ],
+      "tagname": "paper-item-body"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170551
+            },
+            "end": {
+              "line": 76,
+              "column": 170592
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "for",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170690
+            },
+            "end": {
+              "line": 76,
+              "column": 170730
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_forChanged\""
+            }
+          }
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170731
+            },
+            "end": {
+              "line": 76,
+              "column": 170775
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_labelChanged\""
+            }
+          }
+        },
+        {
+          "name": "icon",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170776
+            },
+            "end": {
+              "line": 76,
+              "column": 170803
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "_boundNotifyResize",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170804
+            },
+            "end": {
+              "line": 76,
+              "column": 170892
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_boundUpdateTarget",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170893
+            },
+            "end": {
+              "line": 76,
+              "column": 170982
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "target",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 171398
+            },
+            "end": {
+              "line": 76,
+              "column": 171595
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170984
+            },
+            "end": {
+              "line": 76,
+              "column": 171051
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attributeChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 171052
+            },
+            "end": {
+              "line": 76,
+              "column": 171117
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_forChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 171118
+            },
+            "end": {
+              "line": 76,
+              "column": 171179
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_labelChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 171180
+            },
+            "end": {
+              "line": 76,
+              "column": 171248
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_updateTarget",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 171249
+            },
+            "end": {
+              "line": 76,
+              "column": 171346
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_computeIsIconBadge",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 171347
+            },
+            "end": {
+              "line": 76,
+              "column": 171397
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "updatePosition",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 171596
+            },
+            "end": {
+              "line": 76,
+              "column": 171875
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 76,
+          "column": 170533
+        },
+        "end": {
+          "line": 76,
+          "column": 171876
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "for",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170690
+            },
+            "end": {
+              "line": 76,
+              "column": 170730
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170731
+            },
+            "end": {
+              "line": 76,
+              "column": 170775
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "icon",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 170776
+            },
+            "end": {
+              "line": 76,
+              "column": 170803
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-badge"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "query",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173615
+            },
+            "end": {
+              "line": 76,
+              "column": 173653
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "hideFilterButton",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173654
+            },
+            "end": {
+              "line": 76,
+              "column": 173694
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "disableFilterButton",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173695
+            },
+            "end": {
+              "line": 76,
+              "column": 173738
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "nrSelectedFilters",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173739
+            },
+            "end": {
+              "line": 76,
+              "column": 173778
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "0"
+        },
+        {
+          "name": "icon",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173779
+            },
+            "end": {
+              "line": 76,
+              "column": 173812
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"search\""
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173813
+            },
+            "end": {
+              "line": 76,
+              "column": 173853
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"Search\""
+        },
+        {
+          "name": "keyBindings",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173896
+            },
+            "end": {
+              "line": 76,
+              "column": 173925
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "focus",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173926
+            },
+            "end": {
+              "line": 76,
+              "column": 173964
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_filter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173965
+            },
+            "end": {
+              "line": 76,
+              "column": 174017
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_clear",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174018
+            },
+            "end": {
+              "line": 76,
+              "column": 174103
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_search",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174104
+            },
+            "end": {
+              "line": 76,
+              "column": 174156
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 76,
+          "column": 173580
+        },
+        "end": {
+          "line": 76,
+          "column": 174157
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "query",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173615
+            },
+            "end": {
+              "line": 76,
+              "column": 173653
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "hide-filter-button",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173654
+            },
+            "end": {
+              "line": 76,
+              "column": 173694
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "disable-filter-button",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173695
+            },
+            "end": {
+              "line": 76,
+              "column": 173738
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "nr-selected-filters",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173739
+            },
+            "end": {
+              "line": 76,
+              "column": 173778
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "icon",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173779
+            },
+            "end": {
+              "line": 76,
+              "column": 173812
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "placeholder",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 173813
+            },
+            "end": {
+              "line": 76,
+              "column": 173853
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "query-changed",
+          "description": "Fired when the `query` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [],
+      "tagname": "paper-search-bar"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "horizontal",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174679
+            },
+            "end": {
+              "line": 76,
+              "column": 174743
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_horizontalChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "opened",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174744
+            },
+            "end": {
+              "line": 76,
+              "column": 174810
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "observer": "\"_openedChanged\""
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "transitioning",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174811
+            },
+            "end": {
+              "line": 76,
+              "column": 174861
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true,
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "noAnimation",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174862
+            },
+            "end": {
+              "line": 76,
+              "column": 174888
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_desiredSize",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174889
+            },
+            "end": {
+              "line": 76,
+              "column": 174924
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "hostAttributes",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175122
+            },
+            "end": {
+              "line": 76,
+              "column": 175196
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "dimension",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174926
+            },
+            "end": {
+              "line": 76,
+              "column": 174982
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_dimensionMax",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174983
+            },
+            "end": {
+              "line": 76,
+              "column": 175049
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        },
+        {
+          "name": "_dimensionMaxCss",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175050
+            },
+            "end": {
+              "line": 76,
+              "column": 175121
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "toggle",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175242
+            },
+            "end": {
+              "line": 76,
+              "column": 175285
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "show",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175286
+            },
+            "end": {
+              "line": 76,
+              "column": 175317
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "hide",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175318
+            },
+            "end": {
+              "line": 76,
+              "column": 175349
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "updateSize",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175350
+            },
+            "end": {
+              "line": 76,
+              "column": 175755
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "enableTransition",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175756
+            },
+            "end": {
+              "line": 76,
+              "column": 175890
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_updateTransition",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175891
+            },
+            "end": {
+              "line": 76,
+              "column": 175980
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_horizontalChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 175981
+            },
+            "end": {
+              "line": 76,
+              "column": 176186
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_openedChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 176187
+            },
+            "end": {
+              "line": 76,
+              "column": 176492
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_transitionEnd",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 176493
+            },
+            "end": {
+              "line": 76,
+              "column": 176749
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onTransitionEnd",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 176750
+            },
+            "end": {
+              "line": 76,
+              "column": 176835
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_calcSize",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 176836
+            },
+            "end": {
+              "line": 76,
+              "column": 176914
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 76,
+          "column": 174605
+        },
+        "end": {
+          "line": 76,
+          "column": 176915
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "horizontal",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174679
+            },
+            "end": {
+              "line": 76,
+              "column": 174743
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "opened",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174744
+            },
+            "end": {
+              "line": 76,
+              "column": 174810
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "transitioning",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174811
+            },
+            "end": {
+              "line": 76,
+              "column": 174861
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "no-animation",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 174862
+            },
+            "end": {
+              "line": 76,
+              "column": 174888
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "opened-changed",
+          "description": "Fired when the `opened` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "transitioning-changed",
+          "description": "Fired when the `transitioning` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 76,
+              "column": 174552
+            },
+            "end": {
+              "line": 76,
+              "column": 174565
+            }
+          }
+        }
+      ],
+      "tagname": "iron-collapse"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "elevation",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 181645
+            },
+            "end": {
+              "line": 76,
+              "column": 181698
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "1"
+        },
+        {
+          "name": "animated",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 181699
+            },
+            "end": {
+              "line": 76,
+              "column": 181753
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        }
+      ],
+      "methods": [],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 76,
+          "column": 181612
+        },
+        "end": {
+          "line": 76,
+          "column": 181755
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "elevation",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 181645
+            },
+            "end": {
+              "line": 76,
+              "column": 181698
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "animated",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 76,
+              "column": 181699
+            },
+            "end": {
+              "line": 76,
+              "column": 181753
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 76,
+              "column": 181559
+            },
+            "end": {
+              "line": 76,
+              "column": 181572
+            }
+          }
+        }
+      ],
+      "tagname": "paper-material"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "for",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 826
+            },
+            "end": {
+              "line": 79,
+              "column": 843
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "isOpen",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 844
+            },
+            "end": {
+              "line": 79,
+              "column": 884
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "minLength",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 885
+            },
+            "end": {
+              "line": 79,
+              "column": 916
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "1"
+        },
+        {
+          "name": "maxViewableItems",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 917
+            },
+            "end": {
+              "line": 79,
+              "column": 955
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "7"
+        },
+        {
+          "name": "textProperty",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 956
+            },
+            "end": {
+              "line": 79,
+              "column": 995
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"text\""
+        },
+        {
+          "name": "valueProperty",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 996
+            },
+            "end": {
+              "line": 79,
+              "column": 1037
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"value\""
+        },
+        {
+          "name": "source",
+          "type": "Array",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1038
+            },
+            "end": {
+              "line": 79,
+              "column": 1057
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "selectedOption",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1058
+            },
+            "end": {
+              "line": 79,
+              "column": 1096
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "remoteSource",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1097
+            },
+            "end": {
+              "line": 79,
+              "column": 1133
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "eventNamespace",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1134
+            },
+            "end": {
+              "line": 79,
+              "column": 1172
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"-\""
+        },
+        {
+          "name": "highlightedSuggestion",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1173
+            },
+            "end": {
+              "line": 79,
+              "column": 1227
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "{}"
+        },
+        {
+          "name": "queryFn",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1228
+            },
+            "end": {
+              "line": 79,
+              "column": 1251
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "highlightFirst",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1252
+            },
+            "end": {
+              "line": 79,
+              "column": 1290
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "showResultsOnFocus",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1291
+            },
+            "end": {
+              "line": 79,
+              "column": 1333
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_suggestions",
+          "type": "Array",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1334
+            },
+            "end": {
+              "line": 79,
+              "column": 1392
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_onSuggestionsChanged\""
+            }
+          }
+        },
+        {
+          "name": "_currentIndex",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1393
+            },
+            "end": {
+              "line": 79,
+              "column": 1429
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "-1"
+        },
+        {
+          "name": "_scrollIndex",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1430
+            },
+            "end": {
+              "line": 79,
+              "column": 1464
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "0"
+        },
+        {
+          "name": "_itemHeight",
+          "type": "number",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1465
+            },
+            "end": {
+              "line": 79,
+              "column": 1529
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "observer": "\"_itemHeightChanged\""
+            }
+          },
+          "defaultValue": "36"
+        },
+        {
+          "name": "_value",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1530
+            },
+            "end": {
+              "line": 79,
+              "column": 1551
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_text",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1552
+            },
+            "end": {
+              "line": 79,
+              "column": 1572
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_idItemSeed",
+          "type": "string",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1573
+            },
+            "end": {
+              "line": 79,
+              "column": 1679
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": true
+            }
+          }
+        },
+        {
+          "name": "_bindedFunctions",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1680
+            },
+            "end": {
+              "line": 79,
+              "column": 1780
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_hasItemHighBeenCalculated",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1781
+            },
+            "end": {
+              "line": 79,
+              "column": 1831
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "__customTplRef",
+          "type": "Object",
+          "description": "",
+          "privacy": "private",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1832
+            },
+            "end": {
+              "line": 79,
+              "column": 1853
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_suggestionTemplate",
+          "type": "Function",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3972
+            },
+            "end": {
+              "line": 79,
+              "column": 4168
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "templatize",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 93482
+            },
+            "end": {
+              "line": 0,
+              "column": 93751
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "stamp",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 93752
+            },
+            "end": {
+              "line": 0,
+              "column": 93794
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "modelForElement",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 93795
+            },
+            "end": {
+              "line": 0,
+              "column": 93894
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ],
+          "inheritedFrom": "Polymer.Templatizer"
+        },
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1855
+            },
+            "end": {
+              "line": 79,
+              "column": 2085
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 2086
+            },
+            "end": {
+              "line": 79,
+              "column": 2626
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "detached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 2627
+            },
+            "end": {
+              "line": 79,
+              "column": 2951
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getItemText",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 2952
+            },
+            "end": {
+              "line": 79,
+              "column": 3005
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_showSuggestionsWrapper",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3006
+            },
+            "end": {
+              "line": 79,
+              "column": 3145
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_hideSuggestionsWrapper",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3146
+            },
+            "end": {
+              "line": 79,
+              "column": 3332
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_handleSuggestions",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3333
+            },
+            "end": {
+              "line": 79,
+              "column": 3435
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_remoteSuggestions",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3436
+            },
+            "end": {
+              "line": 79,
+              "column": 3582
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_bindSuggestions",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3583
+            },
+            "end": {
+              "line": 79,
+              "column": 3718
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_createSuggestions",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 3719
+            },
+            "end": {
+              "line": 79,
+              "column": 3971
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_renderSuggestions",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 4169
+            },
+            "end": {
+              "line": 79,
+              "column": 4444
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_clearSuggestions",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 4445
+            },
+            "end": {
+              "line": 79,
+              "column": 4557
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onSuggestionsChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 4558
+            },
+            "end": {
+              "line": 79,
+              "column": 5044
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_selection",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5045
+            },
+            "end": {
+              "line": 79,
+              "column": 5272
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_getItems",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5273
+            },
+            "end": {
+              "line": 79,
+              "column": 5358
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_emptyItems",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5359
+            },
+            "end": {
+              "line": 79,
+              "column": 5403
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getId",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5404
+            },
+            "end": {
+              "line": 79,
+              "column": 5484
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_removeActive",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5485
+            },
+            "end": {
+              "line": 79,
+              "column": 5619
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onKeypress",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5620
+            },
+            "end": {
+              "line": 79,
+              "column": 5950
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "c"
+            }
+          ]
+        },
+        {
+          "name": "_keyenter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 5951
+            },
+            "end": {
+              "line": 79,
+              "column": 6094
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_moveHighlighted",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 6095
+            },
+            "end": {
+              "line": 79,
+              "column": 6601
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_scroll",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 6602
+            },
+            "end": {
+              "line": 79,
+              "column": 7054
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_resetScroll",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7055
+            },
+            "end": {
+              "line": 79,
+              "column": 7117
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_setHighlightedSuggestion",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7118
+            },
+            "end": {
+              "line": 79,
+              "column": 7267
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_fireEvent",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7268
+            },
+            "end": {
+              "line": 79,
+              "column": 7464
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_onSelect",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7465
+            },
+            "end": {
+              "line": 79,
+              "column": 7556
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onBlur",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7557
+            },
+            "end": {
+              "line": 79,
+              "column": 7665
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_onFocus",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7666
+            },
+            "end": {
+              "line": 79,
+              "column": 7806
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_getSuggestionId",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7807
+            },
+            "end": {
+              "line": 79,
+              "column": 7866
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_itemHeightChanged",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7867
+            },
+            "end": {
+              "line": 79,
+              "column": 7983
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "suggestions",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 7984
+            },
+            "end": {
+              "line": 79,
+              "column": 8033
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "hideSuggestions",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 8034
+            },
+            "end": {
+              "line": 79,
+              "column": 8129
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "queryFn",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 8130
+            },
+            "end": {
+              "line": 79,
+              "column": 8411
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 79,
+          "column": 745
+        },
+        "end": {
+          "line": 79,
+          "column": 8412
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "for",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 826
+            },
+            "end": {
+              "line": 79,
+              "column": 843
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "is-open",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 844
+            },
+            "end": {
+              "line": 79,
+              "column": 884
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "min-length",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 885
+            },
+            "end": {
+              "line": 79,
+              "column": 916
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "max-viewable-items",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 917
+            },
+            "end": {
+              "line": 79,
+              "column": 955
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "text-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 956
+            },
+            "end": {
+              "line": 79,
+              "column": 995
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "value-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 996
+            },
+            "end": {
+              "line": 79,
+              "column": 1037
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "source",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1038
+            },
+            "end": {
+              "line": 79,
+              "column": 1057
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "selected-option",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1058
+            },
+            "end": {
+              "line": 79,
+              "column": 1096
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "remote-source",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1097
+            },
+            "end": {
+              "line": 79,
+              "column": 1133
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "event-namespace",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1134
+            },
+            "end": {
+              "line": 79,
+              "column": 1172
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "highlighted-suggestion",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1173
+            },
+            "end": {
+              "line": 79,
+              "column": 1227
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "query-fn",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1228
+            },
+            "end": {
+              "line": 79,
+              "column": 1251
+            }
+          },
+          "metadata": {},
+          "type": "Function"
+        },
+        {
+          "name": "highlight-first",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1252
+            },
+            "end": {
+              "line": 79,
+              "column": 1290
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "show-results-on-focus",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 1291
+            },
+            "end": {
+              "line": 79,
+              "column": 1333
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "is-open-changed",
+          "description": "Fired when the `isOpen` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "selected-option-changed",
+          "description": "Fired when the `selectedOption` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "highlighted-suggestion-changed",
+          "description": "Fired when the `highlightedSuggestion` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "autocomplete-custom-template",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 79,
+              "column": 517
+            },
+            "end": {
+              "line": 79,
+              "column": 581
+            }
+          }
+        }
+      ],
+      "tagname": "paper-autocomplete-suggestions"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "autoValidate",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11254
+            },
+            "end": {
+              "line": 79,
+              "column": 11290
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "autocapitalize",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11291
+            },
+            "end": {
+              "line": 79,
+              "column": 11312
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "errorMessage",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11313
+            },
+            "end": {
+              "line": 79,
+              "column": 11339
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "label",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11340
+            },
+            "end": {
+              "line": 79,
+              "column": 11352
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "noLabelFloat",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11353
+            },
+            "end": {
+              "line": 79,
+              "column": 11389
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "alwaysFloatLabel",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11390
+            },
+            "end": {
+              "line": 79,
+              "column": 11430
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "placeholder",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11431
+            },
+            "end": {
+              "line": 79,
+              "column": 11449
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "required",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11450
+            },
+            "end": {
+              "line": 79,
+              "column": 11482
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "readonly",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11483
+            },
+            "end": {
+              "line": 79,
+              "column": 11515
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "source",
+          "type": "Array",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11516
+            },
+            "end": {
+              "line": 79,
+              "column": 11535
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "textProperty",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11536
+            },
+            "end": {
+              "line": 79,
+              "column": 11575
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"text\""
+        },
+        {
+          "name": "valueProperty",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11576
+            },
+            "end": {
+              "line": 79,
+              "column": 11617
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"value\""
+        },
+        {
+          "name": "value",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11618
+            },
+            "end": {
+              "line": 79,
+              "column": 11647
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          }
+        },
+        {
+          "name": "text",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11648
+            },
+            "end": {
+              "line": 79,
+              "column": 11685
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "notify": true
+            }
+          },
+          "defaultValue": "\"\""
+        },
+        {
+          "name": "disableShowClear",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11686
+            },
+            "end": {
+              "line": 79,
+              "column": 11726
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "remoteSource",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11727
+            },
+            "end": {
+              "line": 79,
+              "column": 11763
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "eventNamespace",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11764
+            },
+            "end": {
+              "line": 79,
+              "column": 11802
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "\"-\""
+        },
+        {
+          "name": "minLength",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11803
+            },
+            "end": {
+              "line": 79,
+              "column": 11834
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "1"
+        },
+        {
+          "name": "pattern",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11835
+            },
+            "end": {
+              "line": 79,
+              "column": 11849
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "allowedPattern",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11850
+            },
+            "end": {
+              "line": 79,
+              "column": 11871
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "charCounter",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11872
+            },
+            "end": {
+              "line": 79,
+              "column": 11907
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "maxlength",
+          "type": "number",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11908
+            },
+            "end": {
+              "line": 79,
+              "column": 11931
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11932
+            },
+            "end": {
+              "line": 79,
+              "column": 11943
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "queryFn",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11944
+            },
+            "end": {
+              "line": 79,
+              "column": 11967
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "highlightFirst",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11968
+            },
+            "end": {
+              "line": 79,
+              "column": 12006
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "showResultsOnFocus",
+          "type": "boolean",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12007
+            },
+            "end": {
+              "line": 79,
+              "column": 12049
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_value",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12050
+            },
+            "end": {
+              "line": 79,
+              "column": 12071
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_text",
+          "type": "?",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12072
+            },
+            "end": {
+              "line": 79,
+              "column": 12092
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "_isClearButtonVisible",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12093
+            },
+            "end": {
+              "line": 79,
+              "column": 12138
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_isSuggestionsOpened",
+          "type": "boolean",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12139
+            },
+            "end": {
+              "line": 79,
+              "column": 12183
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "false"
+        },
+        {
+          "name": "_selectedOption",
+          "type": "Object",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12184
+            },
+            "end": {
+              "line": 79,
+              "column": 12213
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12249
+            },
+            "end": {
+              "line": 79,
+              "column": 12398
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_clear",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12399
+            },
+            "end": {
+              "line": 79,
+              "column": 12640
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_fireEvent",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12641
+            },
+            "end": {
+              "line": 79,
+              "column": 12837
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            },
+            {
+              "name": "b"
+            }
+          ]
+        },
+        {
+          "name": "_textObserver",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12838
+            },
+            "end": {
+              "line": 79,
+              "column": 12924
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_onAutocompleteSelected",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12925
+            },
+            "end": {
+              "line": 79,
+              "column": 13012
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "_showClearButton",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13013
+            },
+            "end": {
+              "line": 79,
+              "column": 13166
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_hideClearButton",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13167
+            },
+            "end": {
+              "line": 79,
+              "column": 13289
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_getId",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13290
+            },
+            "end": {
+              "line": 79,
+              "column": 13370
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "getOption",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13371
+            },
+            "end": {
+              "line": 79,
+              "column": 13432
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "setOption",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13433
+            },
+            "end": {
+              "line": 79,
+              "column": 13560
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "disable",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13561
+            },
+            "end": {
+              "line": 79,
+              "column": 13597
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "enable",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13598
+            },
+            "end": {
+              "line": 79,
+              "column": 13633
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "suggestions",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13634
+            },
+            "end": {
+              "line": 79,
+              "column": 13709
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        },
+        {
+          "name": "validate",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13710
+            },
+            "end": {
+              "line": 79,
+              "column": 13773
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "clear",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13774
+            },
+            "end": {
+              "line": 79,
+              "column": 13834
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "reset",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13835
+            },
+            "end": {
+              "line": 79,
+              "column": 13866
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "hideSuggestions",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13867
+            },
+            "end": {
+              "line": 79,
+              "column": 13972
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "onSelectHandler",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 13973
+            },
+            "end": {
+              "line": 79,
+              "column": 14050
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "a"
+            }
+          ]
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 79,
+          "column": 11217
+        },
+        "end": {
+          "line": 79,
+          "column": 14051
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "auto-validate",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11254
+            },
+            "end": {
+              "line": 79,
+              "column": 11290
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "autocapitalize",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11291
+            },
+            "end": {
+              "line": 79,
+              "column": 11312
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "error-message",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11313
+            },
+            "end": {
+              "line": 79,
+              "column": 11339
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11340
+            },
+            "end": {
+              "line": 79,
+              "column": 11352
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "no-label-float",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11353
+            },
+            "end": {
+              "line": 79,
+              "column": 11389
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "always-float-label",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11390
+            },
+            "end": {
+              "line": 79,
+              "column": 11430
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "placeholder",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11431
+            },
+            "end": {
+              "line": 79,
+              "column": 11449
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "required",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11450
+            },
+            "end": {
+              "line": 79,
+              "column": 11482
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "readonly",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11483
+            },
+            "end": {
+              "line": 79,
+              "column": 11515
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "source",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11516
+            },
+            "end": {
+              "line": 79,
+              "column": 11535
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "text-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11536
+            },
+            "end": {
+              "line": 79,
+              "column": 11575
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "value-property",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11576
+            },
+            "end": {
+              "line": 79,
+              "column": 11617
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "value",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11618
+            },
+            "end": {
+              "line": 79,
+              "column": 11647
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        },
+        {
+          "name": "text",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11648
+            },
+            "end": {
+              "line": 79,
+              "column": 11685
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "disable-show-clear",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11686
+            },
+            "end": {
+              "line": 79,
+              "column": 11726
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "remote-source",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11727
+            },
+            "end": {
+              "line": 79,
+              "column": 11763
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "event-namespace",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11764
+            },
+            "end": {
+              "line": 79,
+              "column": 11802
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "min-length",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11803
+            },
+            "end": {
+              "line": 79,
+              "column": 11834
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "pattern",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11835
+            },
+            "end": {
+              "line": 79,
+              "column": 11849
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "allowed-pattern",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11850
+            },
+            "end": {
+              "line": 79,
+              "column": 11871
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "char-counter",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11872
+            },
+            "end": {
+              "line": 79,
+              "column": 11907
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "maxlength",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11908
+            },
+            "end": {
+              "line": 79,
+              "column": 11931
+            }
+          },
+          "metadata": {},
+          "type": "number"
+        },
+        {
+          "name": "name",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11932
+            },
+            "end": {
+              "line": 79,
+              "column": 11943
+            }
+          },
+          "metadata": {},
+          "type": "string"
+        },
+        {
+          "name": "query-fn",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11944
+            },
+            "end": {
+              "line": 79,
+              "column": 11967
+            }
+          },
+          "metadata": {},
+          "type": "Function"
+        },
+        {
+          "name": "highlight-first",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 11968
+            },
+            "end": {
+              "line": 79,
+              "column": 12006
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        },
+        {
+          "name": "show-results-on-focus",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 12007
+            },
+            "end": {
+              "line": 79,
+              "column": 12049
+            }
+          },
+          "metadata": {},
+          "type": "boolean"
+        }
+      ],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "value-changed",
+          "description": "Fired when the `value` property changes.",
+          "metadata": {}
+        },
+        {
+          "type": "CustomEvent",
+          "name": "text-changed",
+          "description": "Fired when the `text` property changes.",
+          "metadata": {}
+        }
+      ],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "prefix",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 79,
+              "column": 10080
+            },
+            "end": {
+              "line": 79,
+              "column": 10121
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "suffix",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 79,
+              "column": 10240
+            },
+            "end": {
+              "line": 79,
+              "column": 10281
+            }
+          }
+        },
+        {
+          "description": "",
+          "name": "autocomplete-custom-template",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 79,
+              "column": 10911
+            },
+            "end": {
+              "line": 79,
+              "column": 10975
+            }
+          }
+        }
+      ],
+      "tagname": "paper-autocomplete"
+    },
+    {
+      "description": "",
+      "summary": "",
+      "path": "target/classes/static/src/animad-app.html",
+      "properties": [
+        {
+          "name": "dialogElement",
+          "type": "Object",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 14821
+            },
+            "end": {
+              "line": 79,
+              "column": 14848
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          }
+        },
+        {
+          "name": "scrollTarget",
+          "type": "Function",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 14850
+            },
+            "end": {
+              "line": 79,
+              "column": 14894
+            }
+          },
+          "metadata": {
+            "polymer": {
+              "readOnly": false
+            }
+          }
+        }
+      ],
+      "methods": [
+        {
+          "name": "ready",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 14895
+            },
+            "end": {
+              "line": 79,
+              "column": 14966
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "attached",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 14967
+            },
+            "end": {
+              "line": 79,
+              "column": 15065
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "updateScrollState",
+          "description": "",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 15066
+            },
+            "end": {
+              "line": 79,
+              "column": 15380
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
+          "name": "_ensureTarget",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 15381
+            },
+            "end": {
+              "line": 79,
+              "column": 15740
+            }
+          },
+          "metadata": {},
+          "params": []
+        }
+      ],
+      "staticMethods": [],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 79,
+          "column": 14779
+        },
+        "end": {
+          "line": 79,
+          "column": 15741
+        }
+      },
+      "privacy": "public",
+      "superclass": "HTMLElement",
+      "attributes": [
+        {
+          "name": "dialog-element",
+          "description": "",
+          "sourceRange": {
+            "start": {
+              "line": 79,
+              "column": 14821
+            },
+            "end": {
+              "line": 79,
+              "column": 14848
+            }
+          },
+          "metadata": {},
+          "type": "Object"
+        }
+      ],
+      "events": [],
+      "styling": {
+        "cssVariables": [],
+        "selectors": []
+      },
+      "slots": [
+        {
+          "description": "",
+          "name": "",
+          "range": {
+            "file": "target/classes/static/src/animad-app.html",
+            "start": {
+              "line": 79,
+              "column": 14720
+            },
+            "end": {
+              "line": 79,
+              "column": 14733
+            }
+          }
+        }
+      ],
+      "tagname": "paper-dialog-scrollable"
     }
   ],
   "mixins": [
@@ -36202,11 +48097,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
               "column": 15
             }
           },
@@ -36216,17 +48111,17 @@
           "defaultValue": "[]"
         },
         {
-          "name": "_filteredData",
+          "name": "filteredData",
           "type": "Array",
-          "description": "_filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus _filteredData an.",
-          "privacy": "protected",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 26,
+              "line": 36,
               "column": 14
             },
             "end": {
-              "line": 31,
+              "line": 41,
               "column": 15
             }
           },
@@ -36241,11 +48136,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 36,
+              "line": 46,
               "column": 14
             },
             "end": {
-              "line": 41,
+              "line": 51,
               "column": 15
             }
           },
@@ -36261,11 +48156,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -36280,11 +48175,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 81,
+              "line": 91,
               "column": 14
             },
             "end": {
-              "line": 83,
+              "line": 93,
               "column": 15
             }
           },
@@ -36299,11 +48194,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 87,
+              "line": 97,
               "column": 14
             },
             "end": {
-              "line": 92,
+              "line": 102,
               "column": 15
             }
           },
@@ -36319,11 +48214,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 96,
+              "line": 106,
               "column": 14
             },
             "end": {
-              "line": 98,
+              "line": 108,
               "column": 15
             }
           },
@@ -36338,11 +48233,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -36358,11 +48253,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 109,
+              "line": 119,
               "column": 14
             },
             "end": {
-              "line": 112,
+              "line": 122,
               "column": 15
             }
           },
@@ -36378,11 +48273,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 116,
+              "line": 126,
               "column": 14
             },
             "end": {
-              "line": 119,
+              "line": 129,
               "column": 15
             }
           },
@@ -36398,11 +48293,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 125,
+              "line": 135,
               "column": 14
             },
             "end": {
-              "line": 128,
+              "line": 138,
               "column": 15
             }
           },
@@ -36418,11 +48313,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 134,
+              "line": 144,
               "column": 14
             },
             "end": {
-              "line": 137,
+              "line": 147,
               "column": 15
             }
           },
@@ -36438,11 +48333,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 141,
+              "line": 151,
               "column": 14
             },
             "end": {
-              "line": 146,
+              "line": 156,
               "column": 15
             }
           },
@@ -36458,11 +48353,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 148,
+              "line": 158,
               "column": 14
             },
             "end": {
-              "line": 151,
+              "line": 161,
               "column": 15
             }
           },
@@ -36479,11 +48374,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -36499,11 +48394,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -36519,11 +48414,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -36539,11 +48434,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -36559,11 +48454,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -36579,11 +48474,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -36599,11 +48494,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -36619,11 +48514,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -36639,11 +48534,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -36659,11 +48554,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -36679,11 +48574,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -36698,11 +48593,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -36717,11 +48612,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -36737,11 +48632,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -36757,11 +48652,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -36777,11 +48672,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 282,
+              "line": 292,
               "column": 14
             },
             "end": {
-              "line": 284,
+              "line": 294,
               "column": 15
             }
           },
@@ -36796,11 +48691,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 288,
+              "line": 298,
               "column": 14
             },
             "end": {
-              "line": 291,
+              "line": 301,
               "column": 15
             }
           },
@@ -36816,11 +48711,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 296,
+              "line": 306,
               "column": 14
             },
             "end": {
-              "line": 299,
+              "line": 309,
               "column": 15
             }
           },
@@ -36836,11 +48731,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 303,
+              "line": 313,
               "column": 14
             },
             "end": {
-              "line": 306,
+              "line": 316,
               "column": 15
             }
           },
@@ -36856,11 +48751,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 310,
+              "line": 320,
               "column": 14
             },
             "end": {
-              "line": 312,
+              "line": 322,
               "column": 15
             }
           },
@@ -36876,11 +48771,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 326,
+              "line": 336,
               "column": 8
             },
             "end": {
-              "line": 329,
+              "line": 339,
               "column": 9
             }
           },
@@ -36893,11 +48788,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 336,
+              "line": 346,
               "column": 8
             },
             "end": {
-              "line": 366,
+              "line": 376,
               "column": 9
             }
           },
@@ -36909,16 +48804,33 @@
           ]
         },
         {
+          "name": "_onFilter",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 378,
+              "column": 8
+            },
+            "end": {
+              "line": 384,
+              "column": 9
+            }
+          },
+          "metadata": {},
+          "params": []
+        },
+        {
           "name": "_deselectItems",
           "description": "Deselektiert alle Datensätze",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 371,
+              "line": 389,
               "column": 8
             },
             "end": {
-              "line": 379,
+              "line": 397,
               "column": 9
             }
           },
@@ -36935,11 +48847,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 385,
+              "line": 403,
               "column": 8
             },
             "end": {
-              "line": 387,
+              "line": 405,
               "column": 9
             }
           },
@@ -36956,11 +48868,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 393,
+              "line": 411,
               "column": 8
             },
             "end": {
-              "line": 395,
+              "line": 413,
               "column": 9
             }
           },
@@ -36977,11 +48889,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 402,
+              "line": 420,
               "column": 8
             },
             "end": {
-              "line": 404,
+              "line": 422,
               "column": 9
             }
           },
@@ -36998,11 +48910,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 410,
+              "line": 428,
               "column": 8
             },
             "end": {
-              "line": 433,
+              "line": 451,
               "column": 9
             }
           },
@@ -37022,11 +48934,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 440,
+              "line": 458,
               "column": 8
             },
             "end": {
-              "line": 452,
+              "line": 470,
               "column": 9
             }
           },
@@ -37039,11 +48951,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 457,
+              "line": 475,
               "column": 8
             },
             "end": {
-              "line": 462,
+              "line": 480,
               "column": 9
             }
           },
@@ -37060,11 +48972,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 469,
+              "line": 487,
               "column": 8
             },
             "end": {
-              "line": 492,
+              "line": 511,
               "column": 9
             }
           },
@@ -37081,11 +48993,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 498,
+              "line": 517,
               "column": 8
             },
             "end": {
-              "line": 517,
+              "line": 536,
               "column": 9
             }
           },
@@ -37102,11 +49014,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 523,
+              "line": 542,
               "column": 8
             },
             "end": {
-              "line": 539,
+              "line": 558,
               "column": 9
             }
           },
@@ -37119,11 +49031,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 544,
+              "line": 563,
               "column": 8
             },
             "end": {
-              "line": 558,
+              "line": 577,
               "column": 9
             }
           },
@@ -37140,11 +49052,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 563,
+              "line": 582,
               "column": 8
             },
             "end": {
-              "line": 572,
+              "line": 591,
               "column": 9
             }
           },
@@ -37157,11 +49069,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 577,
+              "line": 596,
               "column": 8
             },
             "end": {
-              "line": 580,
+              "line": 599,
               "column": 9
             }
           },
@@ -37174,11 +49086,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 586,
+              "line": 605,
               "column": 8
             },
             "end": {
-              "line": 615,
+              "line": 635,
               "column": 9
             }
           },
@@ -37194,15 +49106,15 @@
         },
         {
           "name": "_transferCellnameToFieldname",
-          "description": "Wandelt den tabellennamen in den korrespondierenden Backend-Feldnamen um",
+          "description": "",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 620,
+              "line": 637,
               "column": 8
             },
             "end": {
-              "line": 642,
+              "line": 657,
               "column": 9
             }
           },
@@ -37222,11 +49134,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 648,
+              "line": 663,
               "column": 8
             },
             "end": {
-              "line": 657,
+              "line": 673,
               "column": 9
             }
           },
@@ -37243,11 +49155,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 662,
+              "line": 678,
               "column": 8
             },
             "end": {
-              "line": 688,
+              "line": 705,
               "column": 9
             }
           },
@@ -37264,11 +49176,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 702,
+              "line": 719,
               "column": 8
             },
             "end": {
-              "line": 706,
+              "line": 723,
               "column": 9
             }
           },
@@ -37288,11 +49200,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 711,
+              "line": 728,
               "column": 8
             },
             "end": {
-              "line": 715,
+              "line": 732,
               "column": 9
             }
           },
@@ -37312,11 +49224,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 720,
+              "line": 737,
               "column": 8
             },
             "end": {
-              "line": 724,
+              "line": 741,
               "column": 9
             }
           },
@@ -37340,7 +49252,7 @@
           "column": 4
         },
         "end": {
-          "line": 725,
+          "line": 742,
           "column": 6
         }
       },
@@ -37352,11 +49264,27 @@
           "description": "`data` enthält die ungefilterten, gefundenen Datensätze als Array.",
           "sourceRange": {
             "start": {
-              "line": 16,
+              "line": 26,
               "column": 14
             },
             "end": {
-              "line": 21,
+              "line": 31,
+              "column": 15
+            }
+          },
+          "metadata": {},
+          "type": "Array"
+        },
+        {
+          "name": "filtered-data",
+          "description": "filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.\n Die Liste zeigt die Einträge aus filteredData an.",
+          "sourceRange": {
+            "start": {
+              "line": 36,
+              "column": 14
+            },
+            "end": {
+              "line": 41,
               "column": 15
             }
           },
@@ -37368,11 +49296,11 @@
           "description": "Das `allFiltersUrl` property gibt an, über welche URL selektierbare Filter geladen werden können.\nDie Antwort muss ein REST-Objekt mit folgender Struktur sein:\n\n`{\"filters\": [{id, [{id, label}, {id2, label2}, ...}, {id2, [{id, label}, ...]}, ...]}`\n\nIst `allFiltersUrl` nicht gesetzt, so wird der Filter-Button im Suche- bzw. Filter-Feld nicht angezeigt.\n\n`filters.id` und `filters.filters.label` können lokalisiert werden. Beispiel für ein allFilters Objekt:\n\n    { \"filters\" : [\n         {\n           \"id\": \"birthday\",\n           \"filters\": [\n             {\"id\": \"0\", \"label\": \"filter_birthday_before_1980\"},\n             {\"id\": \"1\", \"label\": \"filter_birthday_1980_1990\"},\n             {\"id\": \"2\", \"label\": \"filter_birthday_after_1990\"}\n           ]\n         },\n         {\n           \"id\": \"salary\",\n           \"filters\": [\n             {\"id\": \"0\", \"label\": \"filter_salary_less_1000\"},\n             {\"id\": \"1\", \"label\": \"filter_salary_1000_2000\"},\n             {\"id\": \"2\", \"label\": \"filter_salary_2000_3000\"},\n             {\"id\": \"3\", \"label\": \"filter_salary_more_3000\"}\n           ]\n         }\n       ] }\n\nWerden selektierbare Filter verwendet, so muss die Methode\n[`_useSelectedFilters`](#/elements/animad-keepers-list#method-_useSelectedFilters) implementiert werden.",
           "sourceRange": {
             "start": {
-              "line": 75,
+              "line": 85,
               "column": 14
             },
             "end": {
-              "line": 77,
+              "line": 87,
               "column": 15
             }
           },
@@ -37384,11 +49312,11 @@
           "description": "`defaultSearch` enthält die Vorbelegung für den Suche-String, der im Suche-Feld beim Öffnen der Liste angezeigt wird.",
           "sourceRange": {
             "start": {
-              "line": 102,
+              "line": 112,
               "column": 14
             },
             "end": {
-              "line": 105,
+              "line": 115,
               "column": 15
             }
           },
@@ -37400,11 +49328,11 @@
           "description": "`url` ist die URL zur Backend-Suche",
           "sourceRange": {
             "start": {
-              "line": 156,
+              "line": 166,
               "column": 15
             },
             "end": {
-              "line": 159,
+              "line": 169,
               "column": 16
             }
           },
@@ -37416,11 +49344,11 @@
           "description": "`multiSort` gibt an, ob in der Tabelle nach mehreren Feldern sortiert\nwerden kann (multi-sort = \"true\") oder nicht (multi-sort = \"false\").\nStandard: `false`",
           "sourceRange": {
             "start": {
-              "line": 165,
+              "line": 175,
               "column": 15
             },
             "end": {
-              "line": 168,
+              "line": 178,
               "column": 16
             }
           },
@@ -37432,11 +49360,11 @@
           "description": "`hideHeader` gibt an, ob der Listen-Header angezeigt werden soll oder nicht.\nBeim Setzen des Attributs \"hide-header\" wird der Header nicht angezeigt.",
           "sourceRange": {
             "start": {
-              "line": 173,
+              "line": 183,
               "column": 15
             },
             "end": {
-              "line": 176,
+              "line": 186,
               "column": 16
             }
           },
@@ -37448,11 +49376,11 @@
           "description": "`hideNew` gibt an, ob der Neu-Button angezeigt werden soll oder nicht.\nBeim Setzen des Attributs \"hide-new\" wird der Button nicht angezeigt.",
           "sourceRange": {
             "start": {
-              "line": 181,
+              "line": 191,
               "column": 15
             },
             "end": {
-              "line": 184,
+              "line": 194,
               "column": 16
             }
           },
@@ -37464,11 +49392,11 @@
           "description": "`hideDelete` gibt an, ob die Löschen-Buttons im Listen-Header und in den Listen-Zeilen\nangezeigt werden sollen oder nicht.\nBeim Setzen des Attributs \"hide-delete\" werden die Buttons nicht angezeigt.",
           "sourceRange": {
             "start": {
-              "line": 190,
+              "line": 200,
               "column": 15
             },
             "end": {
-              "line": 193,
+              "line": 203,
               "column": 16
             }
           },
@@ -37480,11 +49408,11 @@
           "description": "`hideEdit` gibt an, ob die Edit-Buttons in den Listen-Zeilen\nangezeigt werden sollen oder nicht.\nBeim Setzen des Attributs \"hide-edit\" werden die Buttons nicht angezeigt.",
           "sourceRange": {
             "start": {
-              "line": 199,
+              "line": 209,
               "column": 15
             },
             "end": {
-              "line": 202,
+              "line": 212,
               "column": 16
             }
           },
@@ -37496,11 +49424,11 @@
           "description": "`hideFilter` gibt an, ob der Filter-Button im Listen-Header\nangezeigt werden soll oder nicht.\nBeim Setzen des Attributs \"hide-filter\" wird der Button nicht angezeigt.",
           "sourceRange": {
             "start": {
-              "line": 208,
+              "line": 218,
               "column": 12
             },
             "end": {
-              "line": 211,
+              "line": 221,
               "column": 13
             }
           },
@@ -37512,11 +49440,11 @@
           "description": "`disableFilter` gibt an, ob der Filter-Button im Listen-Header\ndeaktiviert werden soll oder nicht.\nBeim Setzen des Attributs \"disable-filter\" wird der Button deaktiviert.",
           "sourceRange": {
             "start": {
-              "line": 217,
+              "line": 227,
               "column": 12
             },
             "end": {
-              "line": 220,
+              "line": 230,
               "column": 13
             }
           },
@@ -37528,11 +49456,11 @@
           "description": "`disableDelete` gibt an, ob die Löschen-Buttons im Listen-Header und in den Listen-Zeilen\ndeaktiviert werden sollen oder nicht.\nBeim Setzen des Attributs \"disable-delete\" werden die Buttons deaktiviert.",
           "sourceRange": {
             "start": {
-              "line": 226,
+              "line": 236,
               "column": 12
             },
             "end": {
-              "line": 229,
+              "line": 239,
               "column": 13
             }
           },
@@ -37544,11 +49472,11 @@
           "description": "`disableNew` gibt an, ob der Neu-Button im Listen-Header\ndeaktiviert werden soll oder nicht.\nBeim Setzen des Attributs \"disable-new\" wird der Button deaktiviert.",
           "sourceRange": {
             "start": {
-              "line": 235,
+              "line": 245,
               "column": 12
             },
             "end": {
-              "line": 238,
+              "line": 248,
               "column": 13
             }
           },
@@ -37560,11 +49488,11 @@
           "description": "`createPath` gibt an, auf welche Seite die Navigation wechseln soll, wenn der Neu-Button geklickt wurde.",
           "sourceRange": {
             "start": {
-              "line": 242,
+              "line": 252,
               "column": 14
             },
             "end": {
-              "line": 244,
+              "line": 254,
               "column": 15
             }
           },
@@ -37576,11 +49504,11 @@
           "description": "`editPath` gibt an, auf welche Seite die Navigation wechseln soll, wenn der Edit-Button zu einem Datensatz geklickt wurde.",
           "sourceRange": {
             "start": {
-              "line": 248,
+              "line": 258,
               "column": 14
             },
             "end": {
-              "line": 250,
+              "line": 260,
               "column": 15
             }
           },
@@ -37592,11 +49520,11 @@
           "description": "`icon` gibt an, welcher Icon im Suche-Hintergrund angezeigt werden soll.",
           "sourceRange": {
             "start": {
-              "line": 254,
+              "line": 264,
               "column": 12
             },
             "end": {
-              "line": 257,
+              "line": 267,
               "column": 13
             }
           },
@@ -37608,11 +49536,11 @@
           "description": "`loadCompleteData` gibt an, ob beim Öffnen der Liste sofort alle Datensätze gesucht werden sollen\n(Attribut load-complete-data=\"true\") oder nicht (Standard). Ist `loadCompleteData` auf false gesetzt,\ndann kann vor der Suche im Suche-Feld ein Wert mit folgenden Patterns eingegeben werden:\n\n\"<wert>\": Das Backend sucht in allen mit in der Barrakuda DSL \"searchable\" markierten Feldern nach dem eingegebenen <wert>.\n\"<tabellenname>:<wert>\": Der `<tabellenname>` wird auf den entsprechenden Feldnamen im Backend gemappt und das Backend sucht den <wert> im entsprechenden Feld.",
           "sourceRange": {
             "start": {
-              "line": 267,
+              "line": 277,
               "column": 14
             },
             "end": {
-              "line": 270,
+              "line": 280,
               "column": 15
             }
           },
@@ -37624,11 +49552,11 @@
           "description": "`showResults` gibt an, ob angezeigt werden soll, wieviele Datensätze gefunden wurden.",
           "sourceRange": {
             "start": {
-              "line": 274,
+              "line": 284,
               "column": 14
             },
             "end": {
-              "line": 277,
+              "line": 287,
               "column": 15
             }
           },
@@ -37636,7 +49564,14 @@
           "type": "boolean"
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "type": "CustomEvent",
+          "name": "filter-data",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "metadata": {}
+        }
+      ],
       "styling": {
         "cssVariables": [],
         "selectors": []
@@ -37804,7 +49739,7 @@
               "column": 8
             },
             "end": {
-              "line": 198,
+              "line": 200,
               "column": 9
             }
           },
@@ -37824,11 +49759,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 204,
+              "line": 206,
               "column": 8
             },
             "end": {
-              "line": 207,
+              "line": 209,
               "column": 9
             }
           },
@@ -37841,11 +49776,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 214,
+              "line": 216,
               "column": 8
             },
             "end": {
-              "line": 272,
+              "line": 278,
               "column": 9
             }
           },
@@ -37858,11 +49793,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 283,
+              "line": 289,
               "column": 8
             },
             "end": {
-              "line": 285,
+              "line": 291,
               "column": 9
             }
           },
@@ -37885,11 +49820,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 293,
+              "line": 299,
               "column": 8
             },
             "end": {
-              "line": 322,
+              "line": 328,
               "column": 9
             }
           },
@@ -37906,11 +49841,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 330,
+              "line": 336,
               "column": 8
             },
             "end": {
-              "line": 335,
+              "line": 341,
               "column": 9
             }
           },
@@ -37931,7 +49866,7 @@
           "column": 4
         },
         "end": {
-          "line": 336,
+          "line": 342,
           "column": 5
         }
       },
@@ -38197,7 +50132,184 @@
       "slots": []
     }
   ],
+  "metadata": {
+    "polymer": {
+      "behaviors": [
+        {
+          "description": "",
+          "summary": "",
+          "path": "target/classes/static/src/animad-app.html",
+          "properties": [],
+          "methods": [
+            {
+              "name": "templatize",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 0,
+                  "column": 93482
+                },
+                "end": {
+                  "line": 0,
+                  "column": 93751
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "a"
+                },
+                {
+                  "name": "b"
+                }
+              ]
+            },
+            {
+              "name": "stamp",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 0,
+                  "column": 93752
+                },
+                "end": {
+                  "line": 0,
+                  "column": 93794
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "a"
+                }
+              ]
+            },
+            {
+              "name": "modelForElement",
+              "description": "",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 0,
+                  "column": 93795
+                },
+                "end": {
+                  "line": 0,
+                  "column": 93894
+                }
+              },
+              "metadata": {},
+              "params": [
+                {
+                  "name": "a"
+                }
+              ]
+            }
+          ],
+          "staticMethods": [],
+          "demos": [],
+          "metadata": {},
+          "sourceRange": {
+            "start": {
+              "line": 0,
+              "column": 93461
+            },
+            "end": {
+              "line": 0,
+              "column": 93895
+            }
+          },
+          "privacy": "public",
+          "name": "Polymer.Templatizer",
+          "attributes": [],
+          "events": [],
+          "styling": {
+            "cssVariables": [],
+            "selectors": []
+          },
+          "slots": []
+        }
+      ]
+    }
+  },
   "classes": [
+    {
+      "description": "",
+      "summary": "",
+      "path": "src/common-libs/common-utils.html",
+      "properties": [],
+      "methods": [],
+      "staticMethods": [
+        {
+          "name": "csvToArray",
+          "description": "Parst den angebenen Text als CSV und liefert ein Array.\nFullblown-Version - alle Spezialfälle, dafür langsamer.",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 8,
+              "column": 4
+            },
+            "end": {
+              "line": 31,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text",
+              "type": "type",
+              "description": "als CSV"
+            }
+          ],
+          "return": {
+            "desc": "Array als Ergebnis"
+          }
+        },
+        {
+          "name": "simpleCsvToArray",
+          "description": "Parst den angebenen Text als CSV und liefert ein Array. Entfernt leading und \ntrailing spaces.\nSimple Version - schneller aber keine Spezialfälle (z.B. Anführungszeichen o.ä.).",
+          "privacy": "public",
+          "sourceRange": {
+            "start": {
+              "line": 40,
+              "column": 4
+            },
+            "end": {
+              "line": 43,
+              "column": 5
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "text",
+              "type": "type",
+              "description": "als CSV"
+            }
+          ],
+          "return": {
+            "desc": "Array als Ergebnis"
+          }
+        }
+      ],
+      "demos": [],
+      "metadata": {},
+      "sourceRange": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 44,
+          "column": 1
+        }
+      },
+      "privacy": "public",
+      "name": "CommonUtils"
+    },
     {
       "description": "",
       "summary": "",
@@ -38210,11 +50322,11 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 85,
+              "line": 100,
               "column": 12
             },
             "end": {
-              "line": 90,
+              "line": 105,
               "column": 13
             }
           },
@@ -38223,15 +50335,15 @@
         },
         {
           "name": "_navigateTo",
-          "description": "Wird von Formularen in Buttons aufgerufen.\n               Navigiert zum Attribut \"data-routePath\" wenn der Button gedrückt wird.",
+          "description": "Wird von Formularen in Buttons aufgerufen.\n             Navigiert zum Attribut \"data-routePath\" wenn der Button gedrückt wird.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 96,
-              "column": 13
+              "line": 111,
+              "column": 12
             },
             "end": {
-              "line": 100,
+              "line": 115,
               "column": 13
             }
           },
@@ -38248,11 +50360,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 105,
-              "column": 13
+              "line": 120,
+              "column": 12
             },
             "end": {
-              "line": 107,
+              "line": 123,
               "column": 13
             }
           },
@@ -38269,11 +50381,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 113,
+              "line": 129,
               "column": 12
             },
             "end": {
-              "line": 115,
+              "line": 132,
               "column": 13
             }
           },
@@ -38290,16 +50402,20 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 138,
               "column": 12
             },
             "end": {
-              "line": 123,
+              "line": 141,
               "column": 13
             }
           },
           "metadata": {},
-          "params": []
+          "params": [
+            {
+              "name": "e"
+            }
+          ]
         },
         {
           "name": "_send",
@@ -38307,11 +50423,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 129,
+              "line": 147,
               "column": 12
             },
             "end": {
-              "line": 161,
+              "line": 181,
               "column": 13
             }
           },
@@ -38333,15 +50449,15 @@
         },
         {
           "name": "_loadFormData",
-          "description": "Holt sich eine HAL Resource über die URL, die im Property \n'loadUrl' gespeichert ist. Die Nutzdaten werden im 'data' \nProperty gespeichert. Danach werden alle benötigten Links \naufgelöst.\n\nDas Property 'loadUrl' wird ausschließlich von update und read \nFormularen verwendet.",
+          "description": "Holt sich eine HAL Resource über die URL, die im Property\n'loadUrl' gespeichert ist. Die Nutzdaten werden im 'data'\nProperty gespeichert. Danach werden alle benötigten Links\naufgelöst.\n\nDas Property 'loadUrl' wird ausschließlich von update und read\nFormularen verwendet.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 172,
+              "line": 192,
               "column": 12
             },
             "end": {
-              "line": 175,
+              "line": 195,
               "column": 13
             }
           },
@@ -38357,15 +50473,15 @@
         },
         {
           "name": "_loadOptions",
-          "description": "Holt sich eine HAL Resource per OPTIONS Verb.\nIn dieser Ressource sind bei einem create \nFormular die Links zu den Ressourcen Objekten \ngespeichert.\n\nDas Property '_loadOptions' wird ausschließlich \nvon create Formularen verwendet.",
+          "description": "Holt sich eine HAL Resource per OPTIONS Verb.\nIn dieser Ressource sind bei einem create\nFormular die Links zu den Ressourcen Objekten\ngespeichert.\n\nDas Property '_loadOptions' wird ausschließlich\nvon create Formularen verwendet.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 186,
+              "line": 206,
               "column": 12
             },
             "end": {
-              "line": 189,
+              "line": 211,
               "column": 13
             }
           },
@@ -38380,31 +50496,7 @@
           ]
         },
         {
-          "name": "_loadHalData",
-          "description": "",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 191,
-              "column": 12
-            },
-            "end": {
-              "line": 211,
-              "column": 13
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "url"
-            },
-            {
-              "name": "verb"
-            }
-          ]
-        },
-        {
-          "name": "_reloadForm",
+          "name": "_loadProfile",
           "description": "",
           "privacy": "protected",
           "sourceRange": {
@@ -38418,6 +50510,78 @@
             }
           },
           "metadata": {},
+          "params": [
+            {
+              "name": "profileUrl"
+            },
+            {
+              "name": "oldV"
+            }
+          ]
+        },
+        {
+          "name": "_parseProfile",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 217,
+              "column": 12
+            },
+            "end": {
+              "line": 253,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "profile"
+            }
+          ]
+        },
+        {
+          "name": "_loadHalData",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 257,
+              "column": 12
+            },
+            "end": {
+              "line": 277,
+              "column": 13
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "url"
+            },
+            {
+              "name": "verb"
+            },
+            {
+              "name": "target"
+            }
+          ]
+        },
+        {
+          "name": "_reloadForm",
+          "description": "",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 279,
+              "column": 12
+            },
+            "end": {
+              "line": 281,
+              "column": 13
+            }
+          },
+          "metadata": {},
           "params": []
         },
         {
@@ -38426,11 +50590,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 220,
+              "line": 286,
               "column": 12
             },
             "end": {
-              "line": 222,
+              "line": 288,
               "column": 13
             }
           },
@@ -38443,11 +50607,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 227,
+              "line": 293,
               "column": 12
             },
             "end": {
-              "line": 231,
+              "line": 297,
               "column": 13
             }
           },
@@ -38460,11 +50624,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 236,
+              "line": 302,
               "column": 12
             },
             "end": {
-              "line": 239,
+              "line": 305,
               "column": 13
             }
           },
@@ -38477,11 +50641,11 @@
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 244,
+              "line": 310,
               "column": 12
             },
             "end": {
-              "line": 247,
+              "line": 313,
               "column": 13
             }
           },
@@ -38498,11 +50662,11 @@
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 8,
+          "line": 9,
           "column": 45
         },
         "end": {
-          "line": 248,
+          "line": 314,
           "column": 9
         }
       },

--- a/analysis.json
+++ b/analysis.json
@@ -6976,7 +6976,7 @@
         {
           "type": "CustomEvent",
           "name": "filter-data",
-          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten für die Liste neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
           "metadata": {},
           "inheritedFrom": "AnimadListBehavior"
         }
@@ -9889,7 +9889,7 @@
         },
         {
           "name": "_filterData",
-          "description": "Wird ausgelöst durch den Event (TBD).\nFiltert die Daten der Liste. Der `event` enthält die folgenden Informationen:\nevent.detail.filteredData:    Die gefilterten Daten der Liste\nevent.detail.filtersSelected: Die selektierten Filter\nevent.detail.filterString:    Die Eingabe im Filter-Feld",
+          "description": "Wird ausgelöst durch den Event [`event-filter-data`](#/mixins/AnimadListBehavior#event-filter-data).\nFiltert die Daten der Liste. Der `event` enthält die folgenden Informationen:\nevent.detail.filteredData:    Die gefilterten Daten der Liste\nevent.detail.filtersSelected: Die selektierten Filter\nevent.detail.filterString:    Die Eingabe im Filter-Feld",
           "privacy": "protected",
           "sourceRange": {
             "start": {
@@ -12351,47 +12351,6 @@
               "name": "event"
             }
           ]
-        },
-        {
-          "name": "_filter",
-          "description": "Filtert die gefundenen Datensätze nach dem eingegebenen String im Filter-Feld.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 313,
-              "column": 8
-            },
-            "end": {
-              "line": 322,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_useSelectedFilters",
-          "description": "Filtert die gefundenen Datensätze nach den ausgewählten, selektierbaren Filtern.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 327,
-              "column": 8
-            },
-            "end": {
-              "line": 334,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "animal"
-            },
-            {
-              "name": "event"
-            }
-          ]
         }
       ],
       "staticMethods": [],
@@ -12403,7 +12362,7 @@
           "column": 6
         },
         "end": {
-          "line": 336,
+          "line": 309,
           "column": 7
         }
       },
@@ -12794,7 +12753,7 @@
         {
           "type": "CustomEvent",
           "name": "filter-data",
-          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten für die Liste neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
           "metadata": {},
           "inheritedFrom": "AnimadListBehavior"
         }
@@ -13410,15 +13369,15 @@
         {
           "name": "_domain",
           "type": "string",
-          "description": "Das '_domain' property wird benötigt, um\" den richtigen Pfad \nzu den i18n Werten zu erzeugen. Es wird in jedem Element \nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle \neiner view ist der Wert IMMER 'view'.",
+          "description": "Das '_domain' property wird benötigt, um\" den richtigen Pfad\nzu den i18n Werten zu erzeugen. Es wird in jedem Element\nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle\neiner view ist der Wert IMMER 'view'.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 106,
+              "line": 108,
               "column": 10
             },
             "end": {
-              "line": 109,
+              "line": 111,
               "column": 11
             }
           },
@@ -13430,15 +13389,15 @@
         {
           "name": "_entity",
           "type": "string",
-          "description": "Das '_entity' property wird benötigt, um den richtigen Pfad \nzu den i18n Werten zu erzeugen. Es wird in jedem Element \nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle \neiner view ist der Wert immer der Präfix, der im Namen der view\nvor '*-view' steht. Bei animad-animals-view.html also \n'animad-animals'.",
+          "description": "Das '_entity' property wird benötigt, um den richtigen Pfad\nzu den i18n Werten zu erzeugen. Es wird in jedem Element\nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle\neiner view ist der Wert immer der Präfix, der im Namen der view\nvor '*-view' steht. Bei animad-animals-view.html also\n'animad-animals'.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 118,
+              "line": 120,
               "column": 10
             },
             "end": {
-              "line": 121,
+              "line": 123,
               "column": 11
             }
           },
@@ -13454,30 +13413,72 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 124,
               "column": 10
             },
             "end": {
-              "line": 124,
+              "line": 126,
               "column": 11
             }
           },
           "metadata": {
             "polymer": {}
           }
+        },
+        {
+          "name": "_filteredData",
+          "type": "Array",
+          "description": "_filteredData enthält alle Objekte, die auf eingegebene oder ausgewählte Filter zutreffen.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 130,
+              "column": 10
+            },
+            "end": {
+              "line": 135,
+              "column": 11
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
         }
       ],
-      "methods": [],
+      "methods": [
+        {
+          "name": "_filterData",
+          "description": "Wird ausgelöst durch den Event [`event-filter-data`](#/mixins/AnimadListBehavior#event-filter-data).\nFiltert die Daten der Liste. Der `event` enthält die folgenden Informationen:\nevent.detail.filteredData:    Die gefilterten Daten der Liste\nevent.detail.filtersSelected: Die selektierten Filter\nevent.detail.filterString:    Die Eingabe im Filter-Feld",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 146,
+              "column": 6
+            },
+            "end": {
+              "line": 164,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ]
+        }
+      ],
       "staticMethods": [],
       "demos": [],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 94,
+          "line": 96,
           "column": 4
         },
         "end": {
-          "line": 127,
+          "line": 165,
           "column": 5
         }
       },
@@ -13490,11 +13491,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 122,
+              "line": 124,
               "column": 10
             },
             "end": {
-              "line": 124,
+              "line": 126,
               "column": 11
             }
           },
@@ -15035,47 +15036,6 @@
               "name": "event"
             }
           ]
-        },
-        {
-          "name": "_filter",
-          "description": "Filtert die gefundenen Datensätze nach dem eingegebenen String im Filter-Feld.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 284,
-              "column": 8
-            },
-            "end": {
-              "line": 290,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": []
-        },
-        {
-          "name": "_useSelectedFilters",
-          "description": "Filtert die gefundenen Datensätze nach den ausgewählten, selektierbaren Filtern.",
-          "privacy": "protected",
-          "sourceRange": {
-            "start": {
-              "line": 295,
-              "column": 8
-            },
-            "end": {
-              "line": 302,
-              "column": 9
-            }
-          },
-          "metadata": {},
-          "params": [
-            {
-              "name": "enclosure"
-            },
-            {
-              "name": "event"
-            }
-          ]
         }
       ],
       "staticMethods": [],
@@ -15087,7 +15047,7 @@
           "column": 6
         },
         "end": {
-          "line": 304,
+          "line": 281,
           "column": 7
         }
       },
@@ -15478,7 +15438,7 @@
         {
           "type": "CustomEvent",
           "name": "filter-data",
-          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten für die Liste neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
           "metadata": {},
           "inheritedFrom": "AnimadListBehavior"
         }
@@ -16027,15 +15987,15 @@
         {
           "name": "_domain",
           "type": "string",
-          "description": "Das '_domain' property wird benötigt, um\" den richtigen Pfad \nzu den i18n Werten zu erzeugen. Es wird in jedem Element \nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle \neiner view ist der Wert IMMER 'view'.",
+          "description": "Das '_domain' property wird benötigt, um\" den richtigen Pfad\nzu den i18n Werten zu erzeugen. Es wird in jedem Element\nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle\neiner view ist der Wert IMMER 'view'.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 105,
+              "line": 107,
               "column": 10
             },
             "end": {
-              "line": 108,
+              "line": 110,
               "column": 11
             }
           },
@@ -16047,15 +16007,15 @@
         {
           "name": "_entity",
           "type": "string",
-          "description": "Das '_entity' property wird benötigt, um den richtigen Pfad \nzu den i18n Werten zu erzeugen. Es wird in jedem Element \nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle \neiner view ist der Wert immer der Präfix, der im Namen der view\nvor '*-view' steht. Bei animad-enclosures-view.html also \n'animad-enclosures'.",
+          "description": "Das '_entity' property wird benötigt, um den richtigen Pfad\nzu den i18n Werten zu erzeugen. Es wird in jedem Element\nbenötigt, in dem die I18nBehavior verwendet wird. Im Falle\neiner view ist der Wert immer der Präfix, der im Namen der view\nvor '*-view' steht. Bei animad-enclosures-view.html also\n'animad-enclosures'.",
           "privacy": "protected",
           "sourceRange": {
             "start": {
-              "line": 117,
+              "line": 119,
               "column": 10
             },
             "end": {
-              "line": 120,
+              "line": 122,
               "column": 11
             }
           },
@@ -16071,30 +16031,72 @@
           "privacy": "public",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 123,
               "column": 10
             },
             "end": {
-              "line": 123,
+              "line": 125,
               "column": 11
             }
           },
           "metadata": {
             "polymer": {}
           }
+        },
+        {
+          "name": "_filteredData",
+          "type": "Array",
+          "description": "_filteredData enthält alle Objekte, die auf eingegebene oder ausgewählte Filter zutreffen.",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 129,
+              "column": 10
+            },
+            "end": {
+              "line": 134,
+              "column": 11
+            }
+          },
+          "metadata": {
+            "polymer": {}
+          },
+          "defaultValue": "[]"
         }
       ],
-      "methods": [],
+      "methods": [
+        {
+          "name": "_filterData",
+          "description": "Wird ausgelöst durch den Event [`event-filter-data`](#/mixins/AnimadListBehavior#event-filter-data).\nFiltert die Daten der Liste. Der `event` enthält die folgenden Informationen:\nevent.detail.filteredData:    Die gefilterten Daten der Liste\nevent.detail.filtersSelected: Die selektierten Filter\nevent.detail.filterString:    Die Eingabe im Filter-Feld",
+          "privacy": "protected",
+          "sourceRange": {
+            "start": {
+              "line": 146,
+              "column": 6
+            },
+            "end": {
+              "line": 161,
+              "column": 7
+            }
+          },
+          "metadata": {},
+          "params": [
+            {
+              "name": "event"
+            }
+          ]
+        }
+      ],
       "staticMethods": [],
       "demos": [],
       "metadata": {},
       "sourceRange": {
         "start": {
-          "line": 93,
+          "line": 95,
           "column": 4
         },
         "end": {
-          "line": 126,
+          "line": 162,
           "column": 5
         }
       },
@@ -16107,11 +16109,11 @@
           "description": "",
           "sourceRange": {
             "start": {
-              "line": 121,
+              "line": 123,
               "column": 10
             },
             "end": {
-              "line": 123,
+              "line": 125,
               "column": 11
             }
           },
@@ -49568,7 +49570,7 @@
         {
           "type": "CustomEvent",
           "name": "filter-data",
-          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
+          "description": "filter-data\n\nAusgelöst, wenn\n  1. die Daten für die Liste neu gesucht wurden,\n  2. die Eingabe im Filter-Feld geändert wurde,\n  3. die Auswahl der selektierbaren Filter geändert wurde.",
           "metadata": {}
         }
       ],

--- a/src/animad-animal/animad-animals-list.html
+++ b/src/animad-animal/animad-animals-list.html
@@ -292,21 +292,6 @@
           this._search = event.target.search.toLowerCase();
           super._fetchData(this._search);
         }
-
-        /**
-         * Filtert die gefundenen Datensätze neu, wenn die Filter-Selektion geändert wurde.
-         */
-        _filterSelectionData() {
-          this._onFilter();
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze neu, wenn im Filter-Feld eine Änderung durchgeführt wurde.
-         */
-        _filterData(event) {
-          this._filterString = event.target.search.toLowerCase();
-          this._onFilter();
-        }
       }
 
       customElements.define(AnimadAnimalsList.is, AnimadAnimalsList);

--- a/src/animad-animal/animad-animals-list.html
+++ b/src/animad-animal/animad-animals-list.html
@@ -114,7 +114,7 @@
 <!-- Für Suche über Lazy Loading:
      <vaadin-grid id="animad-list" data-provider="[[dataProvider]]"  size="200" multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}"> -->
 
-     <vaadin-grid id="animad-list" items="[[_filteredData]]"  multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}">
+     <vaadin-grid id="animad-list" items="[[filteredData]]"  multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}">
         <vaadin-grid-selection-column auto-select>
         </vaadin-grid-selection-column>
 
@@ -278,8 +278,8 @@
 
         _confirmDeleteRow(e) {
           // this is optional. If not implemented will only ask question (translated): Do you really want to delete this item?
-          var index = this._filteredData.findIndex(item => item.id == e.target.id);
-          var item = this._filteredData[index];
+          var index = this.filteredData.findIndex(item => item.id == e.target.id);
+          var item = this.filteredData[index];
           this._deleteInfo = this.t('modal_deleteinfo', {name: item.name, species: item.species, birthDate: item.birthDate, gender: item.gender, alive: item.alive});
 
           super._confirmDeleteRow(e);
@@ -297,7 +297,7 @@
          * Filtert die gefundenen Datensätze neu, wenn die Filter-Selektion geändert wurde.
          */
         _filterSelectionData() {
-          this._filter();
+          this._onFilter();
         }
 
         /**
@@ -305,35 +305,8 @@
          */
         _filterData(event) {
           this._filterString = event.target.search.toLowerCase();
-          this._filter();
+          this._onFilter();
         }
-
-        /**
-         * Filtert die gefundenen Datensätze nach dem eingegebenen String im Filter-Feld.
-         */
-        _filter(){
-          this._filteredData =
-            this.data.filter(animal =>
-                animal.name.toLowerCase().includes(this._filterString) ||
-                animal.species.toLowerCase().includes(this._filterString) ||
-                animal.birthDate.toLowerCase().includes(this._filterString) ||
-                animal.gender.toString().toLowerCase().includes(this._filterString) ||
-                animal.alive.toLowerCase().includes(this._filterString));
-          this._filteredData = this._filteredData.filter(this._useSelectedFilters, this);
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze nach den ausgewählten, selektierbaren Filtern.
-         */
-        _useSelectedFilters(animal, event) {
-          var isIncluded = true;
-          console.log("Methode _useSelectedFilters ist nicht implementiert!");
-
-          /* Filtern für selektierbare Filter muss manuell implementiert werden */
-
-          return isIncluded;
-        }
-
       }
 
       customElements.define(AnimadAnimalsList.is, AnimadAnimalsList);

--- a/src/animad-animals-view.html
+++ b/src/animad-animals-view.html
@@ -52,7 +52,9 @@
             </animad-animals-list>
             <animad-animal-create-form name="create" load-url="[[backendUrl]]/api/admin_service/animals"></animad-animal-create-form>
             <animad-animal-update-form name="edit" load-url="[[backendUrl]]/api/admin_service/animals{{subroute.path}}"></animad-animal-update-form>
-            <animad-animals-list name="filterexample" url="[[backendUrl]]/api/admin_service/animals" load-complete-data="true"></animad-animals-list>
+            <animad-animals-list name="filterexample" url="[[backendUrl]]/api/admin_service/animals" load-complete-data="true"
+            on-filter-data="_filterData"
+            filtered-data="[[_filteredData]]"></animad-animals-list>
       </div>
       <br />
       <br />
@@ -154,9 +156,8 @@
           this._filteredData.filter(animal =>
               animal.name.toLowerCase().includes(filterString) ||
               animal.species.toLowerCase().includes(filterString) ||
-              animal.birthDate.toLowerCase().includes(filterString) ||
-              animal.gender.toString().toLowerCase().includes(filterString) ||
-              animal.alive.toLowerCase().includes(filterString));
+              (animal.birthData != undefined && animal.birthDate.toLowerCase().includes(filterString)) ||
+              animal.gender.toString().toLowerCase().includes(filterString));
 
         if (selectedFilters != undefined && selectedFilters.length > 0) {
           // GENERATOR: Muss im Projekt implementiert werden.

--- a/src/animad-animals-view.html
+++ b/src/animad-animals-view.html
@@ -29,7 +29,7 @@
         grid-row-gap: 3em;
       }
     </style>
-    
+
     <app-route route="{{route}}" pattern="/:page" data="{{routeData}}" tail="{{subroute}}">
     </app-route>
 
@@ -46,9 +46,11 @@
               default-search='name:Dumbo'
               route="{{subroute}}"
               edit-path="/animals-view/edit"
-              create-path="/animals-view/create">
-            </animad-animals-list>          
-            <animad-animal-create-form name="create" load-url="[[backendUrl]]/api/admin_service/animals"></animad-animal-create-form>            
+              create-path="/animals-view/create"
+              on-filter-data="_filterData"
+              filtered-data="[[_filteredData]]">
+            </animad-animals-list>
+            <animad-animal-create-form name="create" load-url="[[backendUrl]]/api/admin_service/animals"></animad-animal-create-form>
             <animad-animal-update-form name="edit" load-url="[[backendUrl]]/api/admin_service/animals{{subroute.path}}"></animad-animal-update-form>
             <animad-animals-list name="filterexample" url="[[backendUrl]]/api/admin_service/animals" load-complete-data="true"></animad-animals-list>
       </div>
@@ -99,9 +101,9 @@
       static get properties() {
         return {
           /*
-           * Das '_domain' property wird benötigt, um" den richtigen Pfad 
-           * zu den i18n Werten zu erzeugen. Es wird in jedem Element 
-           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle 
+           * Das '_domain' property wird benötigt, um" den richtigen Pfad
+           * zu den i18n Werten zu erzeugen. Es wird in jedem Element
+           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle
            * einer view ist der Wert IMMER 'view'.
            */
           _domain: {
@@ -109,11 +111,11 @@
             value: 'view'
           },
           /*
-           * Das '_entity' property wird benötigt, um den richtigen Pfad 
-           * zu den i18n Werten zu erzeugen. Es wird in jedem Element 
-           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle 
+           * Das '_entity' property wird benötigt, um den richtigen Pfad
+           * zu den i18n Werten zu erzeugen. Es wird in jedem Element
+           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle
            * einer view ist der Wert immer der Präfix, der im Namen der view
-           * vor '*-view' steht. Bei animad-animals-view.html also 
+           * vor '*-view' steht. Bei animad-animals-view.html also
            * 'animad-animals'.
            */
           _entity: {
@@ -122,7 +124,43 @@
           },
           backendUrl: {
               type: String,
-          }
+          },
+          /*
+          *  _filteredData enthält alle Objekte, die auf eingegebene oder ausgewählte Filter zutreffen.
+          */
+          _filteredData: {
+            type: Array,
+            value() {
+              return [];
+            }
+          },
+        }
+      }
+
+      /**
+      * Wird ausgelöst durch den Event [`event-filter-data`](#/mixins/AnimadListBehavior#event-filter-data).
+      * Filtert die Daten der Liste. Der `event` enthält die folgenden Informationen:
+      * event.detail.filteredData:    Die gefilterten Daten der Liste
+      * event.detail.filtersSelected: Die selektierten Filter
+      * event.detail.filterString:    Die Eingabe im Filter-Feld
+      */
+      _filterData(event) {
+        this._filteredData = event.detail.filteredData;
+        var selectedFilters = event.detail.filtersSelected;
+        var filterString = event.detail.filterString;
+
+        // GENERATOR: alle angezeigten String-Felder und alle angezeigten Integer-Felder (toString())
+        this._filteredData =
+          this._filteredData.filter(animal =>
+              animal.name.toLowerCase().includes(filterString) ||
+              animal.species.toLowerCase().includes(filterString) ||
+              animal.birthDate.toLowerCase().includes(filterString) ||
+              animal.gender.toString().toLowerCase().includes(filterString) ||
+              animal.alive.toLowerCase().includes(filterString));
+
+        if (selectedFilters != undefined && selectedFilters.length > 0) {
+          // GENERATOR: Muss im Projekt implementiert werden.
+          console.log("Filtern nach selektierbaren Filtern ist nicht implementiert!");
         }
       }
     }

--- a/src/animad-enclosure/animad-enclosures-list.html
+++ b/src/animad-enclosure/animad-enclosures-list.html
@@ -264,21 +264,6 @@
           super._fetchData(this._search);
         }
 
-        /**
-         * Filtert die gefundenen Datensätze neu, wenn die Filter-Selektion geändert wurde.
-         */
-        _filterSelectionData() {
-          this._onFilter();
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze neu, wenn im Filter-Feld eine Änderung durchgeführt wurde.
-         */
-        _filterData(event) {
-          this._filterString = event.target.search.toLowerCase();
-          this._onFilter();
-        }
-
       }
 
       customElements.define(AnimadEnclosuresList.is, AnimadEnclosuresList);

--- a/src/animad-enclosure/animad-enclosures-list.html
+++ b/src/animad-enclosure/animad-enclosures-list.html
@@ -114,7 +114,7 @@
 <!-- Für Suche über Lazy Loading:
      <vaadin-grid id="animad-list" data-provider="[[dataProvider]]"  size="200" multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}"> -->
 
-     <vaadin-grid id="animad-list" items="[[_filteredData]]"  multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}">
+     <vaadin-grid id="animad-list" items="[[filteredData]]"  multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}">
         <vaadin-grid-selection-column auto-select>
         </vaadin-grid-selection-column>
 
@@ -249,8 +249,8 @@
 
         _confirmDeleteRow(e) {
           // this is optional. If not implemented will only ask question (translated): Do you really want to delete this item?
-          var index = this._filteredData.findIndex(item => item.id == e.target.id);
-          var item = this._filteredData[index];
+          var index = this.filteredData.findIndex(item => item.id == e.target.id);
+          var item = this.filteredData[index];
           this._deleteInfo = this.t('modal_deleteinfo', {name: item.name, cleaningtime: item.cleaningTime});
 
           super._confirmDeleteRow(e);
@@ -268,7 +268,7 @@
          * Filtert die gefundenen Datensätze neu, wenn die Filter-Selektion geändert wurde.
          */
         _filterSelectionData() {
-          this._filter();
+          this._onFilter();
         }
 
         /**
@@ -276,30 +276,7 @@
          */
         _filterData(event) {
           this._filterString = event.target.search.toLowerCase();
-          this._filter();
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze nach dem eingegebenen String im Filter-Feld.
-         */
-        _filter(){
-          this._filteredData =
-            this.data.filter(enclosure =>
-                enclosure.name.toLowerCase().includes(this._filterString) ||
-                enclosure.cleaningtime.toLowerCase().includes(this._filterString));
-          this._filteredData = this._filteredData.filter(this._useSelectedFilters, this);
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze nach den ausgewählten, selektierbaren Filtern.
-         */
-        _useSelectedFilters(enclosure, event) {
-          var isIncluded = true;
-          console.log("Methode _useSelectedFilters ist nicht implementiert!");
-
-          /* Filtern für selektierbare Filter muss manuell implementiert werden */
-
-          return isIncluded;
+          this._onFilter();
         }
 
       }

--- a/src/animad-enclosures-view.html
+++ b/src/animad-enclosures-view.html
@@ -43,7 +43,9 @@
               default-search='name:Elefantenparadies'
               route="{{subroute}}"
               edit-path="/enclosures-view"
-              create-path="/enclosures-view">
+              create-path="/enclosures-view"
+              on-filter-data="_filterData"
+              filtered-data="[[_filteredData]]">
             </animad-enclosures-list>
       </div>
       <br />
@@ -51,19 +53,19 @@
       <hr>
       <h2>[[t('create_sample_heading')]]</h2>
       <animad-enclosure-create-form save-url="[[backendUrl]]/api/admin_service/enclosures" reset>
-      </animad-enclosure-create-form>      
+      </animad-enclosure-create-form>
       <br />
       <br />
       <hr>
       <h2>[[t('create_sample_heading_cancel')]]</h2>
       <animad-enclosure-create-form save-url="[[backendUrl]]/api/admin_service/enclosures" cancel-path="go/anywhere">
-      </animad-enclosure-create-form>      
+      </animad-enclosure-create-form>
       <br />
       <br />
       <hr>
       <h2>[[t('create_with_relation_sample_heading')]]</h2>
       <animad-enclosure-create-form save-url="[[backendUrl]]/api/admin_service/enclosures" cancel-path="go/anywhere" reset keepers>
-      </animad-enclosure-create-form>      
+      </animad-enclosure-create-form>
       <br />
       <br />
       <hr>
@@ -80,7 +82,7 @@
       <br />
       <hr>
       <h2>[[t('update_sample_heading_with_relation')]]</h2>
-      <animad-enclosure-update-form 
+      <animad-enclosure-update-form
         load-url="[[backendUrl]]/api/admin_service/enclosures/3bca5b38-13be-4fd3-b656-fa79a639ddd5" cancel-path="go/anywhere" reset keepers>
       </animad-enclosure-update-form>
       <br />
@@ -98,9 +100,9 @@
       static get properties() {
         return {
           /*
-           * Das '_domain' property wird benötigt, um" den richtigen Pfad 
-           * zu den i18n Werten zu erzeugen. Es wird in jedem Element 
-           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle 
+           * Das '_domain' property wird benötigt, um" den richtigen Pfad
+           * zu den i18n Werten zu erzeugen. Es wird in jedem Element
+           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle
            * einer view ist der Wert IMMER 'view'.
            */
           _domain: {
@@ -108,11 +110,11 @@
             value: 'view'
           },
           /*
-           * Das '_entity' property wird benötigt, um den richtigen Pfad 
-           * zu den i18n Werten zu erzeugen. Es wird in jedem Element 
-           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle 
+           * Das '_entity' property wird benötigt, um den richtigen Pfad
+           * zu den i18n Werten zu erzeugen. Es wird in jedem Element
+           * benötigt, in dem die I18nBehavior verwendet wird. Im Falle
            * einer view ist der Wert immer der Präfix, der im Namen der view
-           * vor '*-view' steht. Bei animad-enclosures-view.html also 
+           * vor '*-view' steht. Bei animad-enclosures-view.html also
            * 'animad-enclosures'.
            */
           _entity: {
@@ -121,7 +123,41 @@
           },
           backendUrl: {
               type: String,
-          }          
+          },
+          /*
+          *  _filteredData enthält alle Objekte, die auf eingegebene oder ausgewählte Filter zutreffen.
+          */
+          _filteredData: {
+            type: Array,
+            value() {
+              return [];
+            }
+          },
+        }
+      }
+
+
+      /**
+      * Wird ausgelöst durch den Event [`event-filter-data`](#/mixins/AnimadListBehavior#event-filter-data).
+      * Filtert die Daten der Liste. Der `event` enthält die folgenden Informationen:
+      * event.detail.filteredData:    Die gefilterten Daten der Liste
+      * event.detail.filtersSelected: Die selektierten Filter
+      * event.detail.filterString:    Die Eingabe im Filter-Feld
+      */
+      _filterData(event) {
+        this._filteredData = event.detail.filteredData;
+        var selectedFilters = event.detail.filtersSelected;
+        var filterString = event.detail.filterString;
+
+        // GENERATOR: alle angezeigten String-Felder und alle angezeigten Integer-Felder (toString())
+        this._filteredData =
+          this._filteredData.filter(enclosure =>
+            enclosure.name.toLowerCase().includes(filterString) ||
+            enclosure.cleaningtime.toLowerCase().includes(filterString));
+
+        if (selectedFilters != undefined && selectedFilters.length > 0) {
+          // GENERATOR: Muss im Projekt implementiert werden.
+          console.log("Filtern nach selektierbaren Filtern ist nicht implementiert!");
         }
       }
     }

--- a/src/animad-keeper/animad-keepers-list.html
+++ b/src/animad-keeper/animad-keepers-list.html
@@ -294,21 +294,6 @@
           super._fetchData(this._search);
         }
 
-        /**
-         * Filtert die gefundenen Datensätze neu, wenn die Filter-Selektion geändert wurde.
-         */
-        _filterSelectionData() {
-          this._onFilter();
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze neu, wenn im Filter-Feld eine Änderung durchgeführt wurde.
-         */
-        _filterData(event) {
-          this._filterString = event.target.search.toLowerCase();
-          this._onFilter();
-        }
-
       }
 
       customElements.define(AnimadKeepersList.is, AnimadKeepersList);

--- a/src/animad-keeper/animad-keepers-list.html
+++ b/src/animad-keeper/animad-keepers-list.html
@@ -115,7 +115,7 @@
 <!-- Für Suche über Lazy Loading:
      <vaadin-grid id="animad-list" data-provider="[[dataProvider]]"  size="200" multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}"> -->
 
-     <vaadin-grid id="animad-list" items="[[_filteredData]]"  multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}">
+     <vaadin-grid id="animad-list" items="[[filteredData]]"  multi-sort="[[multiSort]]" selected-items="{{_selectedItems}}">
         <vaadin-grid-selection-column auto-select>
         </vaadin-grid-selection-column>
 
@@ -279,8 +279,8 @@
 
         _confirmDeleteRow(e) {
           // this is optional. If not implemented will only ask question (translated): Do you really want to delete this item?
-          var index = this._filteredData.findIndex(item => item.id == e.target.id);
-          var item = this._filteredData[index];
+          var index = this.filteredData.findIndex(item => item.id == e.target.id);
+          var item = this.filteredData[index];
           this._deleteInfo = this.t('modal_deleteinfo', {firstName: item.firstName, lastName: item.lastName, employmentDate: item.employmentDate, skill: item.skill,   birthday: item.birthday,  salary: item.salary});
 
           super._confirmDeleteRow(e);
@@ -298,7 +298,7 @@
          * Filtert die gefundenen Datensätze neu, wenn die Filter-Selektion geändert wurde.
          */
         _filterSelectionData() {
-          this._filter();
+          this._onFilter();
         }
 
         /**
@@ -306,34 +306,7 @@
          */
         _filterData(event) {
           this._filterString = event.target.search.toLowerCase();
-          this._filter();
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze nach dem eingegebenen String im Filter-Feld.
-         */
-        _filter(){
-          this._filteredData =
-            this.data.filter(keeper =>
-                keeper.firstName.toLowerCase().includes(this._filterString) ||
-                keeper.lastName.toLowerCase().includes(this._filterString) ||
-                keeper.employmentDate.toLowerCase().includes(this._filterString) ||
-                keeper.skill.toString().toLowerCase().includes(this._filterString) ||
-                keeper.birthday.toLowerCase().includes(this._filterString) ||
-                new String(keeper.salary).toLowerCase().includes(this._filterString));
-          this._filteredData = this._filteredData.filter(this._useSelectedFilters, this);
-        }
-
-        /**
-         * Filtert die gefundenen Datensätze nach den ausgewählten, selektierbaren Filtern.
-         */
-        _useSelectedFilters(keeper, event) {
-          var isIncluded = true;
-          console.log("Methode _useSelectedFilters ist nicht implementiert!");
-
-          /* Filtern für selektierbare Filter muss manuell implementiert werden */
-
-          return isIncluded;
+          this._onFilter();
         }
 
       }

--- a/src/animad-keepers-view.html
+++ b/src/animad-keepers-view.html
@@ -35,12 +35,14 @@
           <iron-pages selected="[[page]]" attr-for-selected="name" fallback-selection="view404" route="{{subroute}}">
               <animad-keepers-list name=""
                 url="[[backendUrl]]/api/admin_service/keepers"
-                default-search='vorname:hans nachname:dampf'
+                default-search='vorname:hans'
                 route="{{subroute}}"
                 edit-path="/keepers-view/edit"
-                create-path="/keepers-view/create">
+                create-path="/keepers-view/create"
+                on-filter-data="_filterData"
+                filtered-data="[[_filteredData]]">
               </animad-keepers-list>
-              <animad-keeper-create-form name="create" 
+              <animad-keeper-create-form name="create"
                 save-url="[[backendUrl]]/api/admin_service/keepers"
                 profile-url="[[backendUrl]]/api/admin_service/profile/keepers"
                 save-path="/keepers-view/"
@@ -50,7 +52,6 @@
                  profile-url="[[backendUrl]]/api/admin_service/profile/keepers"
                  save-path="/keepers-view/"
                  cancel-path="/keepers-view/"></animad-keeper-update-form>
-              <animad-keepers-list name="filterexample" url="[[backendUrl]]/api/admin_service/keepers" load-complete-data="true"></animad-keepers-list>
           </iron-pages>
         </div>
       </div>
@@ -80,11 +81,20 @@
               rootPath: String,
               backendUrl: {
                   type: String
-              }
+              },
+              /*
+              *  _filteredData enthält alle Objekte, die auf eingegebene oder ausgewählte Filter zutreffen.
+              */
+              _filteredData: {
+                type: Array,
+                value() {
+                  return [];
+                }
+              },
           }
 
         }
-            
+
         static get observers() {
             return [
                 '_routePageChanged(routeData.page)',
@@ -92,6 +102,34 @@
         }
         _routePageChanged(page) {
             this.page = page || '';
+        }
+
+        /**
+        * Wird ausgelöst durch den Event [`event-filter-data`](#/mixins/AnimadListBehavior#event-filter-data).
+        * Filtert die Daten der Liste. Der `event` enthält die folgenden Informationen:
+        * event.detail.filteredData:    Die gefilterten Daten der Liste
+        * event.detail.filtersSelected: Die selektierten Filter
+        * event.detail.filterString:    Die Eingabe im Filter-Feld
+        */
+        _filterData(event) {
+          this._filteredData = event.detail.filteredData;
+          var selectedFilters = event.detail.filtersSelected;
+          var filterString = event.detail.filterString;
+
+          // GENERATOR: alle angezeigten String-Felder und alle angezeigten Integer-Felder (toString())
+          this._filteredData =
+            this._filteredData.filter(keeper =>
+                keeper.firstName.toLowerCase().includes(filterString) ||
+                keeper.lastName.toLowerCase().includes(filterString) ||
+                keeper.employmentDate.toLowerCase().includes(filterString) ||
+                keeper.skill.toString().toLowerCase().includes(filterString) ||
+                keeper.birthday.toLowerCase().includes(filterString) ||
+                new String(keeper.salary).toLowerCase().includes(filterString));
+
+          if (selectedFilters != undefined && selectedFilters.length > 0) {
+            // GENERATOR: Muss im Projekt implementiert werden.
+            console.log("Filtern nach selektierbaren Filtern ist nicht implementiert!");
+          }
         }
     }
 

--- a/src/behaviors/animad-list-behavior.html
+++ b/src/behaviors/animad-list-behavior.html
@@ -9,6 +9,16 @@
      */
     let AnimadListBehavior = (superClass) => class extends superClass {
 
+      /**
+      * @event filter-data
+      *
+      * Ausgelöst, wenn
+      *   1. die Daten für die Liste neu gesucht wurden,
+      *   2. die Eingabe im Filter-Feld geändert wurde,
+      *   3. die Auswahl der selektierbaren Filter geändert wurde.
+      */
+
+
         static get properties() {
             return {
               /*
@@ -21,10 +31,10 @@
                 }
               },
               /*
-              *  _filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.
-              *  Die Liste zeigt die Einträge aus _filteredData an.
+              *  filteredData enthält alle Objekte, die auf angegebene oder ausgewählte Filter zutreffen.
+              *  Die Liste zeigt die Einträge aus filteredData an.
               */
-              _filteredData: {
+              filteredData: {
                 type: Array,
                 value() {
                   return this.data;
@@ -336,8 +346,8 @@
         */
         _dataChanged(dataLength) {
           // refresh list data
-          this._filteredData = this.data;
-          this._filter();
+          this.filteredData = this.data;
+          this._onFilter();
 
           // unselect all deleted items
           this._deselectItems(this._deleteItems);
@@ -364,6 +374,14 @@
                 }
             }
           }
+        }
+
+        _onFilter() {
+          this.dispatchEvent(new CustomEvent('filter-data', {
+            bubbles: true,
+            composed: true,
+            detail: {filteredData: this.filteredData, filtersSelected: this._selectedFilters, filterString: this._filterString}
+          }));
         }
 
         /*
@@ -526,8 +544,8 @@
           this._deleteItems = [];
           // loop over all items to delete
           for (var item of this._selectedItems) {
-            // check if _filteredData contains selected item
-            var index = this._filteredData.indexOf(item);
+            // check if filteredData contains selected item
+            var index = this.filteredData.indexOf(item);
 
             if (index >= 0) {
               // yes: add it to deletedItems
@@ -544,12 +562,12 @@
         * Öffnet den Dialog zur Bestätigung, dass der über den Papierkorb selektierte Datensatz gelöscht werden soll.
         */
         _confirmDeleteRow(e) {
-          // find clicked item by id in _filteredData
-          var index = this._filteredData.findIndex(item => item.id == e.target.id);
+          // find clicked item by id in filteredData
+          var index = this.filteredData.findIndex(item => item.id == e.target.id);
 
           // get item of row where delete button was clicked
-          //var item = this._filteredData[e.target.id];
-          var item = this._filteredData[index];
+          //var item = this.filteredData[e.target.id];
+          var item = this.filteredData[index];
 
           // set temporary delete information
           this._deleteItems = [item];

--- a/src/behaviors/animad-list-behavior.html
+++ b/src/behaviors/animad-list-behavior.html
@@ -376,11 +376,26 @@
           }
         }
 
+        /**
+         * Filtert die gefundenen Datensätze neu, wenn die Filter-Selektion geändert wurde.
+         */
+        _filterSelectionData() {
+          this._onFilter();
+        }
+
+        /**
+         * Filtert die gefundenen Datensätze neu, wenn im Filter-Feld eine Änderung durchgeführt wurde.
+         */
+        _filterData(event) {
+          this._filterString = event.target.search.toLowerCase();
+          this._onFilter();
+        }
+
         _onFilter() {
           this.dispatchEvent(new CustomEvent('filter-data', {
             bubbles: true,
             composed: true,
-            detail: {filteredData: this.filteredData, filtersSelected: this._selectedFilters, filterString: this._filterString}
+            detail: {filteredData: this.data, filtersSelected: this._selectedFilters, filterString: this._filterString}
           }));
         }
 


### PR DESCRIPTION
Die Implementierung für das Filtern in <entity>-view.html verschoben. Wird jetzt über einen Event ('filter-data') angestossen. Der Event wird ausgelöst, wenn neu gesucht wird, die Eingabe im Filterfeld geändert wird oder wenn die Selektion der aufklappbaren Filter geändert wird.