### PR TITLE
Openshift

### DIFF
--- a/src/animad-app.html
+++ b/src/animad-app.html
@@ -288,9 +288,18 @@
                     rootPath: String,
                     backendUrl: {
                         type: String,
-                        value: ''
-                    }
-                };
+                        value() {if (window.location.hostname === 'localhost'
+                                        && window.location.port === '8081') {
+                                        //für lokale Entwicklung wollen wir hier einen CORS-Pfad
+                                        //zum API-Gateway
+                                        return 'http://localhost:8082'
+                                    } else {
+                                        //an sonsten soll die eigene Domäne+Pfad verwendet werden
+                                        return ''
+                                    }
+                                }
+                        }
+                }
             }
 
             static get observers() {

--- a/src/animad-app.html
+++ b/src/animad-app.html
@@ -286,10 +286,10 @@
                     // This shouldn't be neccessary, but the Analyzer isn't picking up
                     // Polymer.Element#rootPath
                     rootPath: String,
-                    backendUrl: {
-                        type: String,
-                        value: 'http://localhost:8082'
-                    }
+//                    backendUrl: {
+//                        type: String,
+//                        value: 'http://localhost:8082'
+//                    }
                 };
             }
 

--- a/src/animad-app.html
+++ b/src/animad-app.html
@@ -286,10 +286,10 @@
                     // This shouldn't be neccessary, but the Analyzer isn't picking up
                     // Polymer.Element#rootPath
                     rootPath: String,
-//                    backendUrl: {
-//                        type: String,
-//                        value: 'http://localhost:8082'
-//                    }
+                    backendUrl: {
+                        type: String,
+                        value: ''
+                    }
                 };
             }
 


### PR DESCRIPTION
Benötigt die Branches "openshift" von
- html5
- api-gateway
- admin-service
- user-service

Es gibt nun ein neues Profil "openshift". Dieses lässt sich wie folgt nutzen:

1. Lokal starten ohne Security
mvn spring-boot:run -Dspring.profiles.active=local,no-security

2. Lokal starten mit Security
mvn spring-boot:run
(Profil "local" ist das Standardprofil)

3. Auf Openshift starten ohne Security
mvn spring-boot:run -Dspring.profiles.active=openshift,no-security

(zukünftig, noch nicht in diesem PR, kommt dann noch
4. Auf Openshift starten mit Security
mvn spring-boot:run -Dspring.profiles.active=openshift
oder sogar (wenn wir das Standard-Profil auf "openshift" stellen)
mvn spring-boot:run)

**Achtung:**
mvn spring-boot:run -Dspring.profiles.active=no-security
ist KEINE valide Option mehr.